### PR TITLE
new(event): provide methods to access dirfd

### DIFF
--- a/falco_event/api/event_table.c
+++ b/falco_event/api/event_table.c
@@ -1828,7 +1828,7 @@ const struct ppm_event_info g_event_info[] = {
                                     EF_CREATES_FD | EF_MODIFIES_STATE,
                                     5,
                                     {{"dirfd", PT_FD, PF_DEC},
-                                     {"name", PT_FSRELPATH, PF_NA, DIRFD_PARAM(1)},
+                                     {"name", PT_FSRELPATH, PF_NA, DIRFD_PARAM(0)},
                                      {"flags", PT_FLAGS32, PF_HEX, file_flags},
                                      {"mode", PT_UINT32, PF_OCT},
                                      {"resolve", PT_FLAGS32, PF_HEX, openat2_flags}}},

--- a/falco_event/src/events/types.rs
+++ b/falco_event/src/events/types.rs
@@ -1780,7 +1780,7 @@ event_info! {
                                     EF_CREATES_FD | EF_MODIFIES_STATE,
                                     5,
                                     {{"dirfd", PT_FD, PF_DEC},
-                                     {"name", PT_FSRELPATH, PF_NA, 1},
+                                     {"name", PT_FSRELPATH, PF_NA, 0},
                                      {"flags", PT_FLAGS32, PF_HEX, file_flags},
                                      {"mode", PT_UINT32, PF_OCT},
                                      {"resolve", PT_FLAGS32, PF_HEX, openat2_flags}}},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area ci

> /area event

/area event_derive

> /area plugin

> /area plugin_api

> /area plugin_derive

> /area plugin_tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Instead of a const generic param that's not really possible to use (we don't have methods to access params by index), generate an actual method to get the dirfd corresponding to a PT_FSRELPATH from an event.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
NONE
```