### PR TITLE
fix(plugin): allow unused imports from derive macro

### DIFF
--- a/falco_plugin/src/plugin/exported_tables/table.rs
+++ b/falco_plugin/src/plugin/exported_tables/table.rs
@@ -34,6 +34,7 @@ use std::fmt::{Debug, Formatter};
 /// See [`crate::tables::export`] for details.
 ///
 /// The implementation it's *not* thread-safe.
+#[must_use]
 pub struct Table<K, E>
 where
     K: Key + Ord + Clone,

--- a/falco_plugin_derive/src/lib.rs
+++ b/falco_plugin_derive/src/lib.rs
@@ -165,6 +165,7 @@ pub fn derive_table_metadata(input: TokenStream) -> TokenStream {
 
         #(#field_trait_impls)*
 
+        #[allow(unused_imports)]
         use #private_ns::*;
     )
     .into()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area ci

> /area event

> /area event_derive

> /area plugin

> /area plugin_api

/area plugin_derive

> /area plugin_tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Defining a table and not using it doesn't really warrant a bunch of unused import warnings from the derive macro. On the other hand, not using a table returned from `add_table` is a bug (that causes other plugins to do use-after-free), so at the very least warn about that with `#[must_use]`

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

The `#[must_use]` patch conflicts with https://github.com/falcosecurity/plugin-sdk-rs/pull/4 so whichever goes in first, the other will need a rebase. Such is life, at least the conflict resolution is trivial.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
NONE
```