### PR TITLE
update(plugin): make with_last_error() lazy

### DIFF
--- a/falco_plugin/src/lib.rs
+++ b/falco_plugin/src/lib.rs
@@ -293,7 +293,6 @@ pub mod async_event {
     /// The event type that can be emitted from async event plugins
     pub use falco_event::events::types::PPME_ASYNCEVENT_E as AsyncEvent;
 
-
     pub use crate::plugin::async_event::async_handler::AsyncHandler;
     pub use crate::plugin::async_event::AsyncEventPlugin;
 

--- a/falco_plugin/src/plugin/error/as_result.rs
+++ b/falco_plugin/src/plugin/error/as_result.rs
@@ -35,13 +35,15 @@ where
     type Decorated = anyhow::Result<T>;
 
     fn with_last_error(self, last_error: &LastError) -> Self::Decorated {
-        let Some(msg) = last_error.get() else {
-            return self.map_err(|e| e.into());
-        };
-
         match self {
             Ok(ok) => Ok(ok),
-            Err(_) => self.context(msg),
+            Err(_) => {
+                let Some(msg) = last_error.get() else {
+                    return self.map_err(|e| e.into());
+                };
+
+                self.context(msg)
+            }
         }
     }
 }


### PR DESCRIPTION
Only get the error message from the framework if there was an actual error

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area ci

> /area event

> /area event_derive

/area plugin

> /area plugin_api

> /area plugin_derive

> /area plugin_tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Don't call `get_owner_last_error` unless there's an actual failure.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
NONE
```