### PR TITLE
new(plugin): harden macros against accidental misuse

### DIFF
--- a/falco_plugin/Cargo.toml
+++ b/falco_plugin/Cargo.toml
@@ -12,6 +12,14 @@ categories = ["api-bindings"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+# RUSTFLAGS='--cfg linkage="static"' cargo rustc --crate-type=staticlib -p falco_plugin --example dummy_source
+[lints.rust]
+unexpected_cfgs = { level = "allow", check-cfg = ['cfg(linkage, values("static"))'] }
+
+[[example]]
+name = "dummy_source"
+crate-type = ["cdylib"]
+
 [features]
 thread-safe-tables = ["dep:parking_lot"]
 

--- a/falco_plugin/README.md
+++ b/falco_plugin/README.md
@@ -179,6 +179,17 @@ This happens automatically with statically linked plugins, but with dynamically 
 one macro per capability yourself. If you forget to do this, you will get a compile error pointing you to the right
 macro.
 
+The SDK will also check that your plugin supports at least one capability. During initial development, you might want to
+build a plugin with no capabilities, so this check can be disabled by using the `#[no_capabilities]` attribute:
+
+```ignore
+// dynamically linked plugin:
+plugin!(#[no_capabilities] MyPlugin);
+
+// statically linked plugin
+static_plugin!(#[no_capabilities] MY_PLUGIN = MyPlugin);
+```
+
 ### Event sourcing plugins
 
 Source plugins are used to generate events. The implementation comes in two parts:

--- a/falco_plugin/examples/dummy_source.rs
+++ b/falco_plugin/examples/dummy_source.rs
@@ -1,0 +1,78 @@
+use falco_plugin::anyhow::Error;
+use falco_plugin::base::Plugin;
+use falco_plugin::source::{EventBatch, EventInput, SourcePlugin, SourcePluginInstance};
+use falco_plugin::tables::TablesInput;
+use falco_plugin::{anyhow, FailureReason};
+use std::ffi::{CStr, CString};
+
+struct DummyPlugin;
+
+impl Plugin for DummyPlugin {
+    const NAME: &'static CStr = c"dummy";
+    const PLUGIN_VERSION: &'static CStr = c"0.0.0";
+    const DESCRIPTION: &'static CStr = c"dummy no-op plugin";
+    const CONTACT: &'static CStr = c"rust@localdomain.pl";
+    type ConfigType = String;
+
+    fn new(_input: Option<&TablesInput>, config: Self::ConfigType) -> Result<Self, Error> {
+        log::set_max_level(log::LevelFilter::Trace);
+        if config != "testing" {
+            anyhow::bail!("I only accept \"testing\" as the config string");
+        }
+
+        Ok(Self)
+    }
+
+    fn set_config(&mut self, config: Self::ConfigType) -> Result<(), Error> {
+        if config != "testing" {
+            anyhow::bail!("I only accept \"testing\" as the config string, even in an update");
+        }
+
+        Ok(())
+    }
+}
+
+struct DummyPluginInstance;
+
+impl SourcePluginInstance for DummyPluginInstance {
+    type Plugin = DummyPlugin;
+
+    fn next_batch(
+        &mut self,
+        _plugin: &mut Self::Plugin,
+        _batch: &mut EventBatch,
+    ) -> Result<(), Error> {
+        Err(anyhow::anyhow!("this plugin does nothing").context(FailureReason::Eof))
+    }
+}
+
+impl SourcePlugin for DummyPlugin {
+    type Instance = DummyPluginInstance;
+    const EVENT_SOURCE: &'static CStr = c"dummy";
+    const PLUGIN_ID: u32 = 1111;
+
+    fn open(&mut self, _params: Option<&str>) -> Result<Self::Instance, Error> {
+        Ok(DummyPluginInstance)
+    }
+
+    fn event_to_string(&mut self, _event: &EventInput) -> Result<CString, Error> {
+        Ok(CString::from(c"what event?"))
+    }
+}
+
+// static linking
+#[cfg(linkage = "static")]
+use falco_plugin::static_plugin;
+
+#[cfg(linkage = "static")]
+static_plugin!(MY_PLUGIN = DummyPlugin);
+
+// dynamic linking
+#[cfg(not(linkage = "static"))]
+use falco_plugin::{plugin, source_plugin};
+
+#[cfg(not(linkage = "static"))]
+plugin!(DummyPlugin);
+
+#[cfg(not(linkage = "static"))]
+source_plugin!(DummyPlugin);

--- a/falco_plugin/src/lib.rs
+++ b/falco_plugin/src/lib.rs
@@ -1025,7 +1025,7 @@ pub mod internals {
         pub use crate::plugin::parse::wrappers;
     }
 
-    pub mod async_events {
+    pub mod async_event {
         pub use crate::plugin::async_event::wrappers;
     }
 

--- a/falco_plugin/src/lib.rs
+++ b/falco_plugin/src/lib.rs
@@ -702,7 +702,7 @@ pub mod tables {
     ///         Ok(MyPlugin { exported_table })
     ///     }
     /// }
-    ///# plugin!(MyPlugin);
+    ///# plugin!(#[no_capabilities] MyPlugin);
     /// ```
     pub mod export {
         pub use crate::plugin::exported_tables::field::private::Private;

--- a/falco_plugin/src/lib.rs
+++ b/falco_plugin/src/lib.rs
@@ -659,6 +659,7 @@ pub mod tables {
     /// ```
     /// use std::ffi::{CStr, CString};
     /// use falco_plugin::base::Plugin;
+    ///# use falco_plugin::plugin;
     /// use falco_plugin::tables::TablesInput;
     /// use falco_plugin::tables::export;
     ///
@@ -701,6 +702,7 @@ pub mod tables {
     ///         Ok(MyPlugin { exported_table })
     ///     }
     /// }
+    ///# plugin!(MyPlugin);
     /// ```
     pub mod export {
         pub use crate::plugin::exported_tables::field::private::Private;
@@ -823,6 +825,8 @@ pub mod tables {
     /// use falco_plugin::parse::{EventInput, ParseInput, ParsePlugin};
     /// use falco_plugin::tables::TablesInput;
     /// use falco_plugin::tables::import::{Entry, Field, Table, TableMetadata};
+    ///# use falco_plugin::plugin;
+    ///# use falco_plugin::parse_plugin;
     ///
     /// #[derive(TableMetadata)]
     /// #[entry_type(ImportedThing)]
@@ -884,6 +888,8 @@ pub mod tables {
     ///     }
     /// }
     ///
+    /// # plugin!(MyPlugin);
+    /// # parse_plugin!(MyPlugin);
     /// # // make this doctest a module, not a function: https://github.com/rust-lang/rust/issues/83583#issuecomment-1083300448
     /// # fn main() {}
     /// ```
@@ -910,6 +916,7 @@ pub mod tables {
     /// use falco_plugin::base::Plugin;
     /// use falco_plugin::event::events::types::EventType;
     /// use falco_plugin::parse::{EventInput, ParseInput, ParsePlugin};
+    ///# use falco_plugin::{parse_plugin, plugin};
     /// use falco_plugin::tables::TablesInput;
     /// use falco_plugin::tables::import::{Field, RuntimeEntry, Table};
     ///
@@ -975,6 +982,8 @@ pub mod tables {
     ///         Ok(())
     ///     }
     /// }
+    ///# plugin!(MyPlugin);
+    ///# parse_plugin!(MyPlugin);
     /// ```
     ///
     /// **Note**: in the above example, `ImportedThingTag` is just an empty struct, used to

--- a/falco_plugin/src/plugin/async_event/mod.rs
+++ b/falco_plugin/src/plugin/async_event/mod.rs
@@ -1,5 +1,6 @@
 use crate::base::Plugin;
 use crate::plugin::async_event::async_handler::AsyncHandler;
+use crate::plugin::async_event::wrappers::AsyncPluginExported;
 
 pub mod async_handler;
 pub mod background_task;
@@ -7,7 +8,7 @@ pub mod background_task;
 pub mod wrappers;
 
 /// # Support for asynchronous event plugins
-pub trait AsyncEventPlugin: Plugin {
+pub trait AsyncEventPlugin: Plugin + AsyncPluginExported {
     /// # Event names coming from this plugin
     ///
     /// This constant contains a list describing the name list of all asynchronous events

--- a/falco_plugin/src/plugin/async_event/wrappers.rs
+++ b/falco_plugin/src/plugin/async_event/wrappers.rs
@@ -115,7 +115,7 @@ macro_rules! async_event_plugin {
     ($ty:ty) => {
         $crate::wrap_ffi! {
             #[no_mangle]
-            use $crate::internals::async_events::wrappers: <$ty>;
+            use $crate::internals::async_event::wrappers: <$ty>;
 
             unsafe fn plugin_get_async_events() -> *const ::std::ffi::c_char;
             unsafe fn plugin_get_async_event_sources() -> *const ::std::ffi::c_char;

--- a/falco_plugin/src/plugin/async_event/wrappers.rs
+++ b/falco_plugin/src/plugin/async_event/wrappers.rs
@@ -31,6 +31,8 @@ pub trait AsyncPluginFallbackApi {
         get_async_events: None,
         set_async_event_handler: None,
     };
+
+    const IMPLEMENTS_ASYNC: bool = false;
 }
 impl<T> AsyncPluginFallbackApi for T {}
 
@@ -42,6 +44,8 @@ impl<T: AsyncEventPlugin + 'static> AsyncPluginApi<T> {
         get_async_events: Some(plugin_get_async_events::<T>),
         set_async_event_handler: Some(plugin_set_async_event_handler::<T>),
     };
+
+    pub const IMPLEMENTS_ASYNC: bool = true;
 }
 
 pub extern "C-unwind" fn plugin_get_async_event_sources<T: AsyncEventPlugin + 'static>(

--- a/falco_plugin/src/plugin/base/mod.rs
+++ b/falco_plugin/src/plugin/base/mod.rs
@@ -1,4 +1,5 @@
 use crate::plugin::base::metrics::Metric;
+use crate::plugin::base::wrappers::BasePluginExported;
 use crate::plugin::error::last_error::LastError;
 use crate::plugin::schema::ConfigSchema;
 use crate::plugin::tables::vtable::TablesInput;
@@ -95,7 +96,7 @@ impl<P: Plugin> PluginWrapper<P> {
 /// // generate the actual plugin wrapper code
 /// plugin!(NoOpPlugin);
 /// ```
-pub trait Plugin: Sized {
+pub trait Plugin: BasePluginExported + Sized {
     /// the name of your plugin, must match the plugin name in the Falco config file
     const NAME: &'static CStr;
     /// the version of your plugin
@@ -154,6 +155,7 @@ pub trait Plugin: Sized {
     /// use std::ffi::CStr;
     /// use anyhow::Error;
     /// use falco_plugin::base::{Json, Metric, Plugin};
+    ///# use falco_plugin::plugin;
     /// use falco_plugin::schemars::JsonSchema;
     /// use falco_plugin::serde::Deserialize;
     ///
@@ -199,6 +201,7 @@ pub trait Plugin: Sized {
     ///
     ///     // ...
     /// }
+    ///# plugin!(MyPlugin);
     /// ```
     type ConfigType: ConfigSchema;
 
@@ -270,6 +273,7 @@ pub trait Plugin: Sized {
     ///         [self.my_metric.with_value(MetricValue::U64(10u64))]
     ///     }
     ///# }
+    ///# plugin!(MyPlugin);
     /// ```
     ///
     /// 2. Inline metrics
@@ -307,6 +311,7 @@ pub trait Plugin: Sized {
     ///         )]
     ///     }
     ///# }
+    ///# plugin!(NoOpPlugin);
     /// ```
     fn get_metrics(&mut self) -> impl IntoIterator<Item = Metric> {
         []

--- a/falco_plugin/src/plugin/base/mod.rs
+++ b/falco_plugin/src/plugin/base/mod.rs
@@ -94,7 +94,9 @@ impl<P: Plugin> PluginWrapper<P> {
 /// }
 ///
 /// // generate the actual plugin wrapper code
-/// plugin!(NoOpPlugin);
+/// // note we need to decorate the type name with `#[no_capabilities]` to bypass
+/// // the safeguard against building an invalid plugin
+/// plugin!(#[no_capabilities] NoOpPlugin);
 /// ```
 pub trait Plugin: BasePluginExported + Sized {
     /// the name of your plugin, must match the plugin name in the Falco config file
@@ -201,7 +203,7 @@ pub trait Plugin: BasePluginExported + Sized {
     ///
     ///     // ...
     /// }
-    ///# plugin!(MyPlugin);
+    ///# plugin!(#[no_capabilities] MyPlugin);
     /// ```
     type ConfigType: ConfigSchema;
 
@@ -273,7 +275,7 @@ pub trait Plugin: BasePluginExported + Sized {
     ///         [self.my_metric.with_value(MetricValue::U64(10u64))]
     ///     }
     ///# }
-    ///# plugin!(MyPlugin);
+    ///# plugin!(#[no_capabilities] MyPlugin);
     /// ```
     ///
     /// 2. Inline metrics
@@ -311,7 +313,7 @@ pub trait Plugin: BasePluginExported + Sized {
     ///         )]
     ///     }
     ///# }
-    ///# plugin!(NoOpPlugin);
+    ///# plugin!(#[no_capabilities] NoOpPlugin);
     /// ```
     fn get_metrics(&mut self) -> impl IntoIterator<Item = Metric> {
         []

--- a/falco_plugin/src/plugin/base/wrappers.rs
+++ b/falco_plugin/src/plugin/base/wrappers.rs
@@ -475,7 +475,7 @@ macro_rules! base_plugin_ffi_wrappers {
 
         #[allow(dead_code)]
         pub const fn __plugin_base_api() -> falco_plugin::api::plugin_api {
-            use $crate::internals::async_events::wrappers::AsyncPluginFallbackApi;
+            use $crate::internals::async_event::wrappers::AsyncPluginFallbackApi;
             use $crate::internals::extract::wrappers::ExtractPluginFallbackApi;
             use $crate::internals::listen::wrappers::CaptureListenFallbackApi;
             use $crate::internals::parse::wrappers::ParsePluginFallbackApi;
@@ -497,7 +497,7 @@ macro_rules! base_plugin_ffi_wrappers {
                 __bindgen_anon_3:
                     $crate::internals::parse::wrappers::ParsePluginApi::<$ty>::PARSE_API,
                 __bindgen_anon_4:
-                    $crate::internals::async_events::wrappers::AsyncPluginApi::<$ty>::ASYNC_API,
+                    $crate::internals::async_event::wrappers::AsyncPluginApi::<$ty>::ASYNC_API,
                 __bindgen_anon_5:
                     $crate::internals::listen::wrappers::CaptureListenApi::<$ty>::LISTEN_API,
                 set_config: Some(plugin_set_config),

--- a/falco_plugin/src/plugin/extract/mod.rs
+++ b/falco_plugin/src/plugin/extract/mod.rs
@@ -1,6 +1,7 @@
 use crate::extract::EventInput;
 use crate::plugin::base::Plugin;
 use crate::plugin::extract::schema::ExtractFieldInfo;
+use crate::plugin::extract::wrappers::ExtractPluginExported;
 use crate::tables::LazyTableReader;
 use falco_event::events::types::EventType;
 use falco_plugin_api::ss_plugin_extract_field;
@@ -66,7 +67,7 @@ pub struct ExtractRequest<'c, 'e, 't, P: ExtractPlugin> {
 }
 
 /// # Support for field extraction plugins
-pub trait ExtractPlugin: Plugin + Sized
+pub trait ExtractPlugin: Plugin + ExtractPluginExported + Sized
 where
     Self: 'static,
 {
@@ -168,6 +169,7 @@ where
     ///     ExtractFieldInfo,
     ///     ExtractPlugin,
     ///     ExtractRequest};
+    ///# use falco_plugin::{extract_plugin, plugin};
     /// use falco_plugin::tables::TablesInput;
     ///
     /// struct SampleExtractPlugin;
@@ -211,6 +213,8 @@ where
     ///     ];
     /// }
     ///
+    ///# plugin!(SampleExtractPlugin);
+    ///# extract_plugin!(SampleExtractPlugin);
     /// ```
     const EXTRACT_FIELDS: &'static [ExtractFieldInfo<Self>];
 

--- a/falco_plugin/src/plugin/extract/wrappers.rs
+++ b/falco_plugin/src/plugin/extract/wrappers.rs
@@ -32,6 +32,8 @@ pub trait ExtractPluginFallbackApi {
         get_fields: None,
         extract_fields: None,
     };
+
+    const IMPLEMENTS_EXTRACT: bool = false;
 }
 impl<T> ExtractPluginFallbackApi for T {}
 
@@ -45,6 +47,8 @@ impl<T: ExtractPlugin> ExtractPluginApi<T> {
         get_fields: Some(plugin_get_fields::<T>),
         extract_fields: Some(plugin_extract_fields::<T>),
     };
+
+    pub const IMPLEMENTS_EXTRACT: bool = true;
 }
 
 pub extern "C-unwind" fn plugin_get_fields<T: ExtractPlugin>() -> *const c_char {

--- a/falco_plugin/src/plugin/listen/mod.rs
+++ b/falco_plugin/src/plugin/listen/mod.rs
@@ -5,12 +5,13 @@ pub mod wrappers;
 use crate::base::Plugin;
 use crate::listen::ThreadPool;
 use crate::plugin::error::last_error::LastError;
+use crate::plugin::listen::wrappers::CaptureListenPluginExported;
 use crate::plugin::tables::vtable::writer::LazyTableWriter;
 use crate::tables::LazyTableReader;
 use falco_plugin_api::ss_plugin_capture_listen_input;
 
 /// Support for capture listening plugins
-pub trait CaptureListenPlugin: Plugin {
+pub trait CaptureListenPlugin: Plugin + CaptureListenPluginExported {
     /// # Capture open notification
     ///
     /// This method gets called whenever the capture is started

--- a/falco_plugin/src/plugin/listen/wrappers.rs
+++ b/falco_plugin/src/plugin/listen/wrappers.rs
@@ -7,6 +7,19 @@ use falco_plugin_api::{
     ss_plugin_rc_SS_PLUGIN_FAILURE, ss_plugin_rc_SS_PLUGIN_SUCCESS, ss_plugin_t,
 };
 
+/// Marker trait to mark a capture listen plugin as exported to the API
+///
+/// # Safety
+///
+/// Only implement this trait if you export the plugin either statically or dynamically
+/// to the plugin API. This is handled by the `capture_listen_plugin!` and `static_plugin!` macros, so you
+/// should never need to implement this trait manually.
+#[diagnostic::on_unimplemented(
+    message = "Capture listen plugin is not exported",
+    note = "use either `capture_listen_plugin!` or `static_plugin!`"
+)]
+pub unsafe trait CaptureListenPluginExported {}
+
 pub trait CaptureListenFallbackApi {
     const LISTEN_API: listen_plugin_api = listen_plugin_api {
         capture_open: None,
@@ -85,6 +98,8 @@ pub unsafe extern "C-unwind" fn plugin_capture_close<T: CaptureListenPlugin>(
 #[macro_export]
 macro_rules! capture_listen_plugin {
     ($ty:ty) => {
+        unsafe impl $crate::internals::listen::wrappers::CaptureListenPluginExported for $ty {}
+
         $crate::wrap_ffi! {
             #[no_mangle]
             use $crate::internals::listen::wrappers: <$ty>;

--- a/falco_plugin/src/plugin/listen/wrappers.rs
+++ b/falco_plugin/src/plugin/listen/wrappers.rs
@@ -25,6 +25,8 @@ pub trait CaptureListenFallbackApi {
         capture_open: None,
         capture_close: None,
     };
+
+    const IMPLEMENTS_LISTEN: bool = false;
 }
 
 impl<T> CaptureListenFallbackApi for T {}
@@ -36,6 +38,8 @@ impl<T: CaptureListenPlugin + 'static> CaptureListenApi<T> {
         capture_open: Some(plugin_capture_open::<T>),
         capture_close: Some(plugin_capture_close::<T>),
     };
+
+    pub const IMPLEMENTS_LISTEN: bool = true;
 }
 
 pub unsafe extern "C-unwind" fn plugin_capture_open<T: CaptureListenPlugin>(

--- a/falco_plugin/src/plugin/parse/mod.rs
+++ b/falco_plugin/src/plugin/parse/mod.rs
@@ -1,6 +1,7 @@
 use crate::parse::EventInput;
 use crate::plugin::base::Plugin;
 use crate::plugin::error::last_error::LastError;
+use crate::plugin::parse::wrappers::ParsePluginExported;
 use crate::plugin::tables::vtable::writer::LazyTableWriter;
 use crate::tables::LazyTableReader;
 use falco_event::events::types::EventType;
@@ -10,7 +11,7 @@ use falco_plugin_api::ss_plugin_event_parse_input;
 pub mod wrappers;
 
 /// # Support for event parse plugins
-pub trait ParsePlugin: Plugin {
+pub trait ParsePlugin: Plugin + ParsePluginExported {
     // TODO: document event_type vs anyevent vs individual event types somewhere prominent
 
     /// # Supported event types

--- a/falco_plugin/src/plugin/parse/wrappers.rs
+++ b/falco_plugin/src/plugin/parse/wrappers.rs
@@ -31,6 +31,8 @@ pub trait ParsePluginFallbackApi {
         get_parse_event_sources: None,
         parse_event: None,
     };
+
+    const IMPLEMENTS_PARSE: bool = false;
 }
 impl<T> ParsePluginFallbackApi for T {}
 
@@ -43,6 +45,8 @@ impl<T: ParsePlugin + 'static> ParsePluginApi<T> {
         get_parse_event_sources: Some(plugin_get_parse_event_sources::<T>),
         parse_event: Some(plugin_parse_event::<T>),
     };
+
+    pub const IMPLEMENTS_PARSE: bool = true;
 }
 
 /// # Safety

--- a/falco_plugin/src/plugin/source/mod.rs
+++ b/falco_plugin/src/plugin/source/mod.rs
@@ -1,4 +1,5 @@
 use crate::plugin::base::Plugin;
+use crate::plugin::source::wrappers::SourcePluginExported;
 use crate::source::{EventBatch, EventInput};
 use falco_event::events::types::PPME_PLUGINEVENT_E as PluginEvent;
 use falco_event::events::Event;
@@ -11,7 +12,7 @@ pub mod open_params;
 pub mod wrappers;
 
 /// # Support for event sourcing plugins
-pub trait SourcePlugin: Plugin {
+pub trait SourcePlugin: Plugin + SourcePluginExported {
     /// # Instance type
     ///
     /// Each source plugin defines an instance type. The instance is the object responsible

--- a/falco_plugin/src/plugin/source/wrappers.rs
+++ b/falco_plugin/src/plugin/source/wrappers.rs
@@ -36,6 +36,8 @@ pub trait SourcePluginFallbackApi {
         event_to_string: None,
         next_batch: None,
     };
+
+    const IMPLEMENTS_SOURCE: bool = false;
 }
 impl<T> SourcePluginFallbackApi for T {}
 
@@ -53,6 +55,8 @@ impl<T: SourcePlugin> SourcePluginApi<T> {
         event_to_string: Some(plugin_event_to_string::<T>),
         next_batch: Some(plugin_next_batch::<T>),
     };
+
+    pub const IMPLEMENTS_SOURCE: bool = true;
 }
 
 pub extern "C-unwind" fn plugin_get_event_source<T: SourcePlugin>() -> *const c_char {

--- a/falco_plugin_tests/tests/dummy.rs
+++ b/falco_plugin_tests/tests/dummy.rs
@@ -30,7 +30,10 @@ impl Plugin for DummyPlugin {
     }
 }
 
-static_plugin!(DUMMY_PLUGIN_API = DummyPlugin);
+static_plugin!(
+    #[no_capabilities]
+    DUMMY_PLUGIN_API = DummyPlugin
+);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area ci

> /area event

> /area event_derive

/area plugin

> /area plugin_api

> /area plugin_derive

> /area plugin_tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

The macros used to export plugin capabilities are a major footgun: it's easy for them to get out of sync with the actual implemented traits (forget adding a corresponding macro when implementing a trait).

This PR adds validation which ensures that:
* all plugin capabilities are exported (when using dynamic linkage)
* a plugin implements at least one capability (though this can be overridden when starting development)

This required a change in building statically/dynamically linked plugins from a single source, though that use case is obscure enough, at least for now.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
NONE
```