### PR TITLE
fix(build): fix non_local_definitions warning in Rust 1.83

### DIFF
--- a/falco_plugin/src/plugin/base/wrappers.rs
+++ b/falco_plugin/src/plugin/base/wrappers.rs
@@ -318,6 +318,8 @@ macro_rules! wrap_ffi {
 #[macro_export]
 macro_rules! plugin {
     (unsafe { $maj:expr; $min:expr; $patch:expr } => #[no_capabilities] $ty:ty) => {
+        unsafe impl $crate::internals::base::wrappers::BasePluginExported for $ty {}
+
         $crate::base_plugin_ffi_wrappers!($maj; $min; $patch => #[no_mangle] $ty);
     };
     (unsafe { $maj:expr; $min:expr; $patch:expr } => $ty:ty) => {
@@ -449,6 +451,7 @@ macro_rules! static_plugin {
         };
 
         // a static plugin automatically exports all capabilities
+        unsafe impl $crate::internals::base::wrappers::BasePluginExported for $ty {}
         unsafe impl $crate::internals::async_event::wrappers::AsyncPluginExported for $ty {}
         unsafe impl $crate::internals::extract::wrappers::ExtractPluginExported for $ty {}
         unsafe impl $crate::internals::listen::wrappers::CaptureListenPluginExported for $ty {}
@@ -496,8 +499,6 @@ macro_rules! ensure_plugin_capabilities {
 #[macro_export]
 macro_rules! base_plugin_ffi_wrappers {
     ($maj:expr; $min:expr; $patch:expr => #[$attr:meta] $ty:ty) => {
-        unsafe impl $crate::internals::base::wrappers::BasePluginExported for $ty {}
-
         #[$attr]
         pub extern "C-unwind" fn plugin_get_required_api_version() -> *const std::ffi::c_char {
             $crate::internals::base::wrappers::plugin_get_required_api_version::<


### PR DESCRIPTION
Incidentally, this seems to also fix a warning from RustRover about unimplemented traits (that were implemented inside `const {}` blocks).

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area ci

> /area event

> /area event_derive

> /area plugin

> /area plugin_api

> /area plugin_derive

> /area plugin_tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
NONE
```