### PR TITLE
new(AsyncEventPlugin): helper to create async events

### DIFF
--- a/falco_plugin/src/lib.rs
+++ b/falco_plugin/src/lib.rs
@@ -208,7 +208,6 @@ pub mod parse {
 /// use falco_plugin::base::Plugin;
 /// use falco_plugin::{async_event_plugin, plugin};
 /// use falco_plugin::async_event::{
-///     AsyncEvent,
 ///     AsyncEventPlugin,
 ///     AsyncHandler,
 ///     BackgroundTask};
@@ -249,22 +248,8 @@ pub mod parse {
 ///         // start a new thread
 ///         // waiting up to 100ms between events for the stop request
 ///         self.thread = Some(self.task.spawn(std::time::Duration::from_millis(100), move || {
-///             // build an event
-///             let event = AsyncEvent {
-///                 plugin_id: Some(0),
-///                 name: Some(c"sample_async"),
-///                 data: Some(b"hello"),
-///             };
-///
-///             let metadata = EventMetadata::default();
-///
-///             let event = Event {
-///                 metadata,
-///                 params: event,
-///             };
-///
-///             // submit it to the main event loop
-///             handler.emit(event)?;
+///             // submit an async event to the main event loop
+///             handler.emit(Self::async_event(c"sample_async", b"hello"))?;
 ///             Ok(())
 ///         })?);
 ///         Ok(())

--- a/falco_plugin/src/plugin/async_event/mod.rs
+++ b/falco_plugin/src/plugin/async_event/mod.rs
@@ -2,6 +2,9 @@ use crate::base::Plugin;
 use crate::plugin::async_event::async_handler::AsyncHandler;
 use crate::plugin::async_event::wrappers::AsyncPluginExported;
 
+use falco_event::events::types::PPME_ASYNCEVENT_E as AsyncEvent;
+use falco_event::events::Event;
+
 pub mod async_handler;
 pub mod background_task;
 #[doc(hidden)]
@@ -48,4 +51,20 @@ pub trait AsyncEventPlugin: Plugin + AsyncPluginExported {
     ///
     /// **Note**: [`AsyncEventPlugin::start_async`] can be called again, with a different [`AsyncHandler`].
     fn stop_async(&mut self) -> Result<(), anyhow::Error>;
+
+    /// # A helper method to create an asynchronous event
+    fn async_event<'a>(name: &'a std::ffi::CStr, data: &'a [u8]) -> Event<AsyncEvent<'a>> {
+        let event = AsyncEvent {
+            plugin_id: None, // gets populated by the framework, shall be None
+            name: Some(name),
+            data: Some(data),
+        };
+
+        let metadata = falco_event::events::EventMetadata::default();
+
+        Event {
+            metadata,
+            params: event,
+        }
+    }
 }

--- a/falco_plugin_tests/tests/async.rs
+++ b/falco_plugin_tests/tests/async.rs
@@ -1,7 +1,6 @@
 use falco_plugin::anyhow::{self, Error};
-use falco_plugin::async_event::{AsyncEvent, AsyncEventPlugin, AsyncHandler, BackgroundTask};
+use falco_plugin::async_event::{AsyncEventPlugin, AsyncHandler, BackgroundTask};
 use falco_plugin::base::Plugin;
-use falco_plugin::event::events::{Event, EventMetadata};
 use falco_plugin::extract::EventInput;
 use falco_plugin::source::{EventBatch, SourcePlugin, SourcePluginInstance};
 use falco_plugin::tables::TablesInput;
@@ -70,34 +69,10 @@ impl AsyncEventPlugin for DummyPlugin {
 
         self.thread = Some(self.task.spawn(Duration::from_millis(100), move || {
             dbg!("emitting event");
-            let event = AsyncEvent {
-                plugin_id: Some(0),
-                name: Some(c"dummy_async"),
-                data: Some(b"hello"),
-            };
-
-            let metadata = EventMetadata::default();
-
-            let event = Event {
-                metadata,
-                params: event,
-            };
-            handler.emit(event)?;
-
-            let event = AsyncEvent {
-                plugin_id: Some(0),
-                name: Some(c"invalid_event_name"),
-                data: Some(b"hello"),
-            };
-
-            let metadata = EventMetadata::default();
-
-            let event = Event {
-                metadata,
-                params: event,
-            };
-            assert!(handler.emit(event).is_err());
-
+            handler.emit(Self::async_event(c"dummy_async", b"hello"))?;
+            assert!(handler
+                .emit(Self::async_event(c"invalid_event_name", b"hello"))
+                .is_err());
             Ok(())
         })?);
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area plugin

/area plugin_tests


**What this PR does / why we need it**:
Reduce the boilerplate to create async events by introducing AsyncEventPlugin::async_event

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
Introduce AsyncEventPlugin::async_event helper to generate async events
```