### PR TITLE
fix(plugin): match erase/add_entry behavior with libs

### DIFF
--- a/falco_plugin/src/plugin/exported_tables/wrappers.rs
+++ b/falco_plugin/src/plugin/exported_tables/wrappers.rs
@@ -160,7 +160,6 @@ where
     ss_plugin_rc_SS_PLUGIN_SUCCESS
 }
 
-// TODO(spec) is removing a nonexistent entry an error?
 // SAFETY: all pointers must be valid
 unsafe extern "C-unwind" fn erase_table_entry<K, E>(
     table: *mut ss_plugin_table_t,
@@ -179,9 +178,11 @@ where
             return ss_plugin_rc_SS_PLUGIN_FAILURE;
         };
         let key = K::from_data(key);
-        table.erase(key);
+        match table.erase(key) {
+            None => ss_plugin_rc_SS_PLUGIN_FAILURE,
+            Some(_) => ss_plugin_rc_SS_PLUGIN_SUCCESS,
+        }
     }
-    ss_plugin_rc_SS_PLUGIN_SUCCESS
 }
 
 // SAFETY: `table` must be a valid pointer to Table<K,E>
@@ -205,7 +206,6 @@ where
     }
 }
 
-// TODO(spec) what if the entry already exists?
 // SAFETY: all pointers must be valid
 unsafe extern "C-unwind" fn add_table_entry<K, E>(
     table: *mut ss_plugin_table_t,


### PR DESCRIPTION
In the built-in libs tables, erasing a nonexistent entry is an error, while adding an entry that overwrites an already existing one is fine.

Since there's no explicit spec for this, AFAICT, let's align our tables to that behavior as well.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area ci

> /area event

> /area event_derive

/area plugin

> /area plugin_api

> /area plugin_derive

> /area plugin_tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
NONE
```