### PR TITLE
fix(plugin): allow string and bool table keys

### DIFF
--- a/falco_plugin/src/plugin/exported_tables/field/table.rs
+++ b/falco_plugin/src/plugin/exported_tables/field/table.rs
@@ -6,11 +6,14 @@ use crate::plugin::exported_tables::ref_shared::RefShared;
 use crate::plugin::exported_tables::table::Table;
 use crate::plugin::tables::data::Key;
 use anyhow::Error;
+use std::borrow::Borrow;
 use std::ffi::CStr;
 
 impl<K, E> HasMetadata for Box<Table<K, E>>
 where
-    K: Key + Ord + Clone,
+    K: Key + Ord,
+    K: Borrow<<K as Key>::Borrowed>,
+    <K as Key>::Borrowed: Ord + ToOwned<Owned = K>,
     E: Entry,
     E::Metadata: TableMetadata,
 {

--- a/falco_plugin/src/plugin/exported_tables/field_value/table.rs
+++ b/falco_plugin/src/plugin/exported_tables/field_value/table.rs
@@ -6,10 +6,13 @@ use crate::plugin::exported_tables::field_value::traits::{seal, StaticField};
 use crate::plugin::exported_tables::table::Table;
 use crate::plugin::tables::data::{FieldTypeId, Key};
 use falco_plugin_api::ss_plugin_state_data;
+use std::borrow::Borrow;
 
 impl<K, E> seal::Sealed for Box<Table<K, E>>
 where
-    K: Key + Ord + Clone,
+    K: Key + Ord,
+    K: Borrow<<K as Key>::Borrowed>,
+    <K as Key>::Borrowed: Ord + ToOwned<Owned = K>,
     E: Entry,
     E::Metadata: TableMetadata + Clone,
 {
@@ -17,7 +20,9 @@ where
 
 impl<K, E> FieldValue for Box<Table<K, E>>
 where
-    K: Key + Ord + Clone,
+    K: Key + Ord,
+    K: Borrow<<K as Key>::Borrowed>,
+    <K as Key>::Borrowed: Ord + ToOwned<Owned = K>,
     E: Entry,
     E::Metadata: TableMetadata + Clone,
 {
@@ -38,7 +43,9 @@ where
 
 impl<K, E> StaticField for Box<Table<K, E>>
 where
-    K: Key + Ord + Clone,
+    K: Key + Ord,
+    K: Borrow<<K as Key>::Borrowed>,
+    <K as Key>::Borrowed: Ord + ToOwned<Owned = K>,
     E: Entry,
     E::Metadata: TableMetadata + Clone,
 {
@@ -48,7 +55,9 @@ where
 
 impl<K, E> TryFrom<DynamicFieldValue> for Box<Table<K, E>>
 where
-    K: Key + Ord + Clone,
+    K: Key + Ord,
+    K: Borrow<<K as Key>::Borrowed>,
+    <K as Key>::Borrowed: Ord + ToOwned<Owned = K>,
     E: Entry,
     E::Metadata: TableMetadata + Clone,
 {

--- a/falco_plugin/src/plugin/exported_tables/table.rs
+++ b/falco_plugin/src/plugin/exported_tables/table.rs
@@ -246,3 +246,29 @@ where
         self.metadata.add_field(name, field_type, read_only)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::plugin::exported_tables::entry::dynamic::DynamicEntry;
+    use crate::tables::export::Table;
+    use crate::tables::import::Bool;
+    use crate::tables::TablesInput;
+    use std::ffi::CString;
+
+    // Just a compile test
+    #[allow(unused)]
+    fn add_table(input: &TablesInput) -> anyhow::Result<()> {
+        input.add_table(Table::<i8, DynamicEntry>::new(c"exported")?)?;
+        input.add_table(Table::<i16, DynamicEntry>::new(c"exported")?)?;
+        input.add_table(Table::<i32, DynamicEntry>::new(c"exported")?)?;
+        input.add_table(Table::<i64, DynamicEntry>::new(c"exported")?)?;
+        input.add_table(Table::<u8, DynamicEntry>::new(c"exported")?)?;
+        input.add_table(Table::<u16, DynamicEntry>::new(c"exported")?)?;
+        input.add_table(Table::<u32, DynamicEntry>::new(c"exported")?)?;
+        input.add_table(Table::<u64, DynamicEntry>::new(c"exported")?)?;
+        input.add_table(Table::<Bool, DynamicEntry>::new(c"exported")?)?;
+        input.add_table(Table::<CString, DynamicEntry>::new(c"exported")?)?;
+
+        Ok(())
+    }
+}

--- a/falco_plugin/src/plugin/exported_tables/vtable.rs
+++ b/falco_plugin/src/plugin/exported_tables/vtable.rs
@@ -8,6 +8,7 @@ use falco_plugin_api::{
     ss_plugin_table_input, ss_plugin_table_reader_vtable, ss_plugin_table_reader_vtable_ext,
     ss_plugin_table_writer_vtable, ss_plugin_table_writer_vtable_ext,
 };
+use std::borrow::Borrow;
 
 pub(crate) struct Vtable {
     pub(crate) input: ss_plugin_table_input,
@@ -18,7 +19,9 @@ pub(crate) struct Vtable {
 
 impl<K, E> Table<K, E>
 where
-    K: Key + Ord + Clone,
+    K: Key + Ord,
+    K: Borrow<<K as Key>::Borrowed>,
+    <K as Key>::Borrowed: Ord + ToOwned<Owned = K>,
     E: Entry,
     E::Metadata: TableMetadata,
 {

--- a/falco_plugin/src/plugin/exported_tables/wrappers.rs
+++ b/falco_plugin/src/plugin/exported_tables/wrappers.rs
@@ -12,12 +12,15 @@ use falco_plugin_api::{
     ss_plugin_table_writer_vtable_ext,
 };
 use num_traits::FromPrimitive;
+use std::borrow::Borrow;
 use std::ffi::{c_char, CStr};
 
 // SAFETY: `table` must be a valid pointer to Table<K,E>
 unsafe extern "C-unwind" fn get_table_name<K, E>(table: *mut ss_plugin_table_t) -> *const c_char
 where
-    K: Key + Ord + Clone,
+    K: Key + Ord,
+    K: Borrow<<K as Key>::Borrowed>,
+    <K as Key>::Borrowed: Ord + ToOwned<Owned = K>,
     E: Entry,
     E::Metadata: TableMetadata,
 {
@@ -32,7 +35,9 @@ where
 // SAFETY: `table` must be a valid pointer to Table<K,E>
 unsafe extern "C-unwind" fn get_table_size<K, E>(table: *mut ss_plugin_table_t) -> u64
 where
-    K: Key + Ord + Clone,
+    K: Key + Ord,
+    K: Borrow<<K as Key>::Borrowed>,
+    <K as Key>::Borrowed: Ord + ToOwned<Owned = K>,
     E: Entry,
     E::Metadata: TableMetadata,
 {
@@ -51,7 +56,9 @@ unsafe extern "C-unwind" fn get_table_entry<K, E>(
     key: *const ss_plugin_state_data,
 ) -> *mut ss_plugin_table_entry_t
 where
-    K: Key + Ord + Clone,
+    K: Key + Ord,
+    K: Borrow<<K as Key>::Borrowed>,
+    <K as Key>::Borrowed: Ord + ToOwned<Owned = K>,
     E: Entry,
     E::Metadata: TableMetadata,
 {
@@ -79,7 +86,9 @@ unsafe extern "C-unwind" fn read_entry_field<K, E>(
     out: *mut ss_plugin_state_data,
 ) -> ss_plugin_rc
 where
-    K: Key + Ord + Clone,
+    K: Key + Ord,
+    K: Borrow<<K as Key>::Borrowed>,
+    <K as Key>::Borrowed: Ord + ToOwned<Owned = K>,
     E: Entry,
     E::Metadata: TableMetadata,
 {
@@ -123,7 +132,9 @@ unsafe extern "C-unwind" fn iterate_entries<K, E>(
     state: *mut ss_plugin_table_iterator_state_t,
 ) -> ss_plugin_bool
 where
-    K: Key + Ord + Clone,
+    K: Key + Ord,
+    K: Borrow<<K as Key>::Borrowed>,
+    <K as Key>::Borrowed: Ord + ToOwned<Owned = K>,
     E: Entry,
     E::Metadata: TableMetadata,
 {
@@ -147,7 +158,9 @@ where
 // SAFETY: `table` must be a valid pointer to Table<K,E>
 unsafe extern "C-unwind" fn clear_table<K, E>(table: *mut ss_plugin_table_t) -> ss_plugin_rc
 where
-    K: Key + Ord + Clone,
+    K: Key + Ord,
+    K: Borrow<<K as Key>::Borrowed>,
+    <K as Key>::Borrowed: Ord + ToOwned<Owned = K>,
     E: Entry,
     E::Metadata: TableMetadata,
 {
@@ -166,7 +179,9 @@ unsafe extern "C-unwind" fn erase_table_entry<K, E>(
     key: *const ss_plugin_state_data,
 ) -> ss_plugin_rc
 where
-    K: Key + Ord + Clone,
+    K: Key + Ord,
+    K: Borrow<<K as Key>::Borrowed>,
+    <K as Key>::Borrowed: Ord + ToOwned<Owned = K>,
     E: Entry,
     E::Metadata: TableMetadata,
 {
@@ -190,7 +205,9 @@ unsafe extern "C-unwind" fn create_table_entry<K, E>(
     table: *mut ss_plugin_table_t,
 ) -> *mut ss_plugin_table_entry_t
 where
-    K: Key + Ord + Clone,
+    K: Key + Ord,
+    K: Borrow<<K as Key>::Borrowed>,
+    <K as Key>::Borrowed: Ord + ToOwned<Owned = K>,
     E: Entry,
     E::Metadata: TableMetadata,
 {
@@ -213,7 +230,9 @@ unsafe extern "C-unwind" fn add_table_entry<K, E>(
     entry: *mut ss_plugin_table_entry_t,
 ) -> *mut ss_plugin_table_entry_t
 where
-    K: Key + Ord + Clone,
+    K: Key + Ord,
+    K: Borrow<<K as Key>::Borrowed>,
+    <K as Key>::Borrowed: Ord + ToOwned<Owned = K>,
     E: Entry,
     E::Metadata: TableMetadata,
 {
@@ -246,7 +265,9 @@ unsafe extern "C-unwind" fn write_entry_field<K, E>(
     value: *const ss_plugin_state_data,
 ) -> ss_plugin_rc
 where
-    K: Key + Ord + Clone,
+    K: Key + Ord,
+    K: Borrow<<K as Key>::Borrowed>,
+    <K as Key>::Borrowed: Ord + ToOwned<Owned = K>,
     E: Entry,
     E::Metadata: TableMetadata,
 {
@@ -273,7 +294,9 @@ unsafe extern "C-unwind" fn list_table_fields<K, E>(
     nfields: *mut u32,
 ) -> *const ss_plugin_table_fieldinfo
 where
-    K: Key + Ord + Clone,
+    K: Key + Ord,
+    K: Borrow<<K as Key>::Borrowed>,
+    <K as Key>::Borrowed: Ord + ToOwned<Owned = K>,
     E: Entry,
     E::Metadata: TableMetadata,
 {
@@ -294,7 +317,9 @@ unsafe extern "C-unwind" fn get_table_field<K, E>(
     data_type: ss_plugin_state_type,
 ) -> *mut ss_plugin_table_field_t
 where
-    K: Key + Ord + Clone,
+    K: Key + Ord,
+    K: Borrow<<K as Key>::Borrowed>,
+    <K as Key>::Borrowed: Ord + ToOwned<Owned = K>,
     E: Entry,
     E::Metadata: TableMetadata,
 {
@@ -324,7 +349,9 @@ unsafe extern "C-unwind" fn add_table_field<K, E>(
     data_type: ss_plugin_state_type,
 ) -> *mut ss_plugin_table_field_t
 where
-    K: Key + Ord + Clone,
+    K: Key + Ord,
+    K: Borrow<<K as Key>::Borrowed>,
+    <K as Key>::Borrowed: Ord + ToOwned<Owned = K>,
     E: Entry,
     E::Metadata: TableMetadata,
 {
@@ -349,7 +376,9 @@ where
 
 pub(crate) fn reader_vtable<K, E>() -> ss_plugin_table_reader_vtable_ext
 where
-    K: Key + Ord + Clone,
+    K: Key + Ord,
+    K: Borrow<<K as Key>::Borrowed>,
+    <K as Key>::Borrowed: Ord + ToOwned<Owned = K>,
     E: Entry,
     E::Metadata: TableMetadata,
 {
@@ -365,7 +394,9 @@ where
 
 pub(crate) fn writer_vtable<K, E>() -> ss_plugin_table_writer_vtable_ext
 where
-    K: Key + Ord + Clone,
+    K: Key + Ord,
+    K: Borrow<<K as Key>::Borrowed>,
+    <K as Key>::Borrowed: Ord + ToOwned<Owned = K>,
     E: Entry,
     E::Metadata: TableMetadata,
 {
@@ -381,7 +412,9 @@ where
 
 pub(crate) fn fields_vtable<K, E>() -> ss_plugin_table_fields_vtable_ext
 where
-    K: Key + Ord + Clone,
+    K: Key + Ord,
+    K: Borrow<<K as Key>::Borrowed>,
+    <K as Key>::Borrowed: Ord + ToOwned<Owned = K>,
     E: Entry,
     E::Metadata: TableMetadata,
 {

--- a/falco_plugin/src/plugin/tables/data.rs
+++ b/falco_plugin/src/plugin/tables/data.rs
@@ -171,7 +171,7 @@ impl_table_data_direct!(i64 => s64: FieldTypeId::I64);
 /// value, we cannot convert it on the fly to the native Rust type.
 ///
 /// This type serves as a wrapper, exposing conversion methods to/from Rust bool.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct Bool(pub(crate) ss_plugin_bool);
 

--- a/falco_plugin/src/plugin/tables/vtable/mod.rs
+++ b/falco_plugin/src/plugin/tables/vtable/mod.rs
@@ -12,6 +12,7 @@ use falco_plugin_api::{
     ss_plugin_table_fields_vtable, ss_plugin_table_info, ss_plugin_table_input,
     ss_plugin_table_reader_vtable, ss_plugin_table_t, ss_plugin_table_writer_vtable,
 };
+use std::borrow::Borrow;
 use std::ffi::CStr;
 use thiserror::Error;
 
@@ -161,7 +162,9 @@ impl<'t> TablesInput<'t> {
     /// going out of scope, which will lead to crashes in plugins using your table).
     pub fn add_table<K, E>(&self, table: Table<K, E>) -> Result<Box<Table<K, E>>, anyhow::Error>
     where
-        K: Key + Ord + Clone,
+        K: Key + Ord,
+        K: Borrow<<K as Key>::Borrowed>,
+        <K as Key>::Borrowed: Ord + ToOwned<Owned = K>,
         E: Entry,
         E::Metadata: TableMetadata,
     {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area ci

> /area event

> /area event_derive

/area plugin

> /area plugin_api

> /area plugin_derive

> /area plugin_tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

We cannot have an owned CStr to be used as a table key and we cannot build a &CString from a *const c_char that we get from the API, so use the Borrow trait to separate the two usages.

Also, derive a few traits (Ord in particular) for the Bool type so it can be used as a table key too.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

The meat of the string key patch is using .to_owned() to convert between borrowed and owned representations of the key (in Table::insert) and returning a separate borrowed type from Key::from_data. The rest is propagating the new trait bounds all over the place.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
NONE
```