### PR TITLE
fix(plugin): make subtable error handling more robust

### DIFF
--- a/falco_plugin/src/plugin/tables/table/raw.rs
+++ b/falco_plugin/src/plugin/tables/table/raw.rs
@@ -329,7 +329,12 @@ impl RawTable {
             anyhow::bail!("Failed to get field value for temporary table entry")
         }
 
-        let input = unsafe { &*(val.table as *mut falco_plugin_api::ss_plugin_table_input) };
+        let input = val.table as *mut falco_plugin_api::ss_plugin_table_input;
+        let input = unsafe { input.as_mut() };
+        let Some(input) = input else {
+            anyhow::bail!("Temporary table entry has a null value for table");
+        };
+
         if input.key_type != K::TYPE_ID as ss_plugin_state_type {
             anyhow::bail!(
                 "Bad key type, requested {:?}, table has {:?}",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area ci

> /area event

> /area event_derive

/area plugin

> /area plugin_api

> /area plugin_derive

> /area plugin_tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

1. fix(plugin): do not leak temporary table entry in error path
When read_entry_field failed on the temporary entry, we leaked
the temporary entry itself (did not destroy it before returning).

Move the cleanup code into a destructor so we don't need to worry
about it again.

2. fix(plugin): add null check for temporary subtable

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
NONE
```