### PR TITLE
fix(plugin): check source instance for null before destroying

### DIFF
--- a/falco_plugin/src/plugin/source/wrappers.rs
+++ b/falco_plugin/src/plugin/source/wrappers.rs
@@ -171,6 +171,9 @@ pub unsafe extern "C-unwind" fn plugin_close<T: SourcePlugin>(
     };
 
     let instance = instance as *mut SourcePluginInstanceWrapper<T::Instance>;
+    if instance.is_null() {
+        return;
+    }
     unsafe {
         let mut inst = Box::from_raw(instance);
         actual_plugin.plugin.close(&mut inst.instance);

--- a/falco_plugin_tests/tests/dummy_source_fail.rs
+++ b/falco_plugin_tests/tests/dummy_source_fail.rs
@@ -1,0 +1,68 @@
+use falco_plugin::anyhow::Error;
+use falco_plugin::base::Plugin;
+use falco_plugin::source::{EventBatch, EventInput, SourcePlugin, SourcePluginInstance};
+use falco_plugin::tables::TablesInput;
+use falco_plugin::{anyhow, static_plugin, FailureReason};
+use std::ffi::{CStr, CString};
+
+struct DummyPlugin;
+
+impl Plugin for DummyPlugin {
+    const NAME: &'static CStr = c"dummy";
+    const PLUGIN_VERSION: &'static CStr = c"0.0.0";
+    const DESCRIPTION: &'static CStr = c"dummy no-op plugin";
+    const CONTACT: &'static CStr = c"rust@localdomain.pl";
+    type ConfigType = ();
+
+    fn new(_input: Option<&TablesInput>, _config: Self::ConfigType) -> Result<Self, Error> {
+        log::set_max_level(log::LevelFilter::Trace);
+        Ok(Self)
+    }
+
+    fn set_config(&mut self, _config: Self::ConfigType) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+struct DummyPluginInstance;
+
+impl SourcePluginInstance for DummyPluginInstance {
+    type Plugin = DummyPlugin;
+
+    fn next_batch(
+        &mut self,
+        _plugin: &mut Self::Plugin,
+        _batch: &mut EventBatch,
+    ) -> Result<(), Error> {
+        Err(anyhow::anyhow!("this plugin does nothing").context(FailureReason::Eof))
+    }
+}
+
+impl SourcePlugin for DummyPlugin {
+    type Instance = DummyPluginInstance;
+    const EVENT_SOURCE: &'static CStr = c"dummy";
+    const PLUGIN_ID: u32 = 1111;
+
+    fn open(&mut self, _params: Option<&str>) -> Result<Self::Instance, Error> {
+        anyhow::bail!("failed!")
+    }
+
+    fn event_to_string(&mut self, _event: &EventInput) -> Result<CString, Error> {
+        Ok(CString::from(c"what event?"))
+    }
+}
+
+static_plugin!(DUMMY_PLUGIN_API = DummyPlugin);
+
+#[cfg(test)]
+mod tests {
+    use falco_plugin::base::Plugin;
+    use falco_plugin_tests::{init_plugin, instantiate_tests, TestDriver};
+
+    fn test_dummy_next<D: TestDriver>() {
+        let (driver, _plugin) = init_plugin::<D>(&super::DUMMY_PLUGIN_API, c"").unwrap();
+        assert!(driver.start_capture(super::DummyPlugin::NAME, c"").is_err());
+    }
+
+    instantiate_tests!(test_dummy_next);
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area ci

> /area event

> /area event_derive

/area plugin

> /area plugin_api

> /area plugin_derive

> /area plugin_tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

After open() on a source instance fails, the plugin API still calls close() on it (with a non-NULL plugin and a NULL instance). We were missing the required NULL check and so crashed promptly.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
NONE
```