### PR TITLE
fix(tests): handle Option<T> extraction for the native driver

### DIFF
--- a/falco_plugin_tests/src/common.rs
+++ b/falco_plugin_tests/src/common.rs
@@ -63,6 +63,8 @@ pub trait CapturingTestDriver {
         event: &Self::Event,
     ) -> anyhow::Result<Option<String>>;
 
+    fn event_field_is_none(&mut self, field_name: &CStr, event: &Self::Event) -> bool;
+
     fn get_metrics(&mut self) -> anyhow::Result<Vec<SinspMetric>>;
 
     fn next_event_as_str(&mut self) -> anyhow::Result<Option<String>> {

--- a/falco_plugin_tests/src/ffi.rs
+++ b/falco_plugin_tests/src/ffi.rs
@@ -214,6 +214,20 @@ impl CapturingTestDriver for SinspTestDriver<CaptureStarted> {
         }
     }
 
+    // `sinsp` does not distinguish between a failed extraction and a successful one
+    // that does not return any data. Our wrapper (c++/sinsp_test_driver.cpp) then considers
+    // "no result" from sinsp an error, so we treat that error as an indicator of extracting
+    // a None value.
+    fn event_field_is_none(&mut self, field_name: &CStr, event: &Self::Event) -> bool {
+        unsafe {
+            self.driver
+                .as_mut()
+                .unwrap()
+                .event_field_as_string(field_name.as_ptr(), &event.event)
+                .is_err()
+        }
+    }
+
     fn get_metrics(&mut self) -> anyhow::Result<Vec<SinspMetric>> {
         let mut out = Vec::new();
         let metrics = self.driver.as_mut().unwrap().get_metrics()?;

--- a/falco_plugin_tests/tests/extract_types.rs
+++ b/falco_plugin_tests/tests/extract_types.rs
@@ -250,7 +250,8 @@ static_plugin!(DUMMY_PLUGIN_API = DummyPlugin);
 
 macro_rules! assert_field_variant_eq {
     ($driver:expr, $event:expr, $field_name:expr, $expected:expr) => {
-        let expected = $expected.as_slice();
+        let expected = $expected;
+        let expected = expected.as_slice();
         let actual = $driver
             .event_field_as_string(c_str_macro::c_str!($field_name), &$event)
             .unwrap()
@@ -333,55 +334,26 @@ mod tests {
             ["(Hello, World!,Hello, World!,Hello, World!)"]
         );
 
-        let s = driver
-            .event_field_as_string(c"dummy.reltime", &event)
-            .unwrap()
-            .unwrap();
-        assert!(s == "10000000" || s == "10ms");
-        let s = driver
-            .event_field_as_string(c"dummy.reltime_opt", &event)
-            .unwrap()
-            .unwrap();
-        assert!(s == "10000000" || s == "10ms");
-        assert!(driver.event_field_is_none(c"dummy.reltime_opt_none", &event));
-        let s = driver
-            .event_field_as_string(c"dummy.vec_reltime", &event)
-            .unwrap()
-            .unwrap();
-        assert!(s == "(10000000,20000000,30000000)" || s == "(10ms,20ms,30ms)");
-        let s = driver
-            .event_field_as_string(c"dummy.vec_reltime_opt", &event)
-            .unwrap()
-            .unwrap();
-        assert!(s == "(10000000,20000000,30000000)" || s == "(10ms,20ms,30ms)");
-        assert!(driver.event_field_is_none(c"dummy.vec_reltime_opt_none", &event));
+        assert_field_eq!(
+            driver,
+            event,
+            reltime,
+            ["10000000", "10ms"],
+            ["(10000000,20000000,30000000)", "(10ms,20ms,30ms)"]
+        );
 
         let ts_10ms = epoch_offset_to_rfc3389(Duration::from_millis(10));
         let ts_20ms = epoch_offset_to_rfc3389(Duration::from_millis(20));
         let ts_30ms = epoch_offset_to_rfc3389(Duration::from_millis(30));
-        let s = driver
-            .event_field_as_string(c"dummy.abstime", &event)
-            .unwrap()
-            .unwrap();
-        assert!(s == "10000000" || s == ts_10ms);
-        let s = driver
-            .event_field_as_string(c"dummy.abstime_opt", &event)
-            .unwrap()
-            .unwrap();
-        assert!(s == "10000000" || s == ts_10ms);
-        assert!(driver.event_field_is_none(c"dummy.abstime_opt_none", &event));
         let timestamps = format!("({ts_10ms},{ts_20ms},{ts_30ms})");
-        let s = driver
-            .event_field_as_string(c"dummy.vec_abstime", &event)
-            .unwrap()
-            .unwrap();
-        assert!(s == "(10000000,20000000,30000000)" || s == timestamps);
-        let s = driver
-            .event_field_as_string(c"dummy.vec_abstime_opt", &event)
-            .unwrap()
-            .unwrap();
-        assert!(s == "(10000000,20000000,30000000)" || s == timestamps);
-        assert!(driver.event_field_is_none(c"dummy.vec_abstime_opt_none", &event));
+
+        assert_field_eq!(
+            driver,
+            event,
+            abstime,
+            ["10000000", ts_10ms.as_str()],
+            ["(10000000,20000000,30000000)", timestamps.as_str()]
+        );
 
         assert_field_eq!(driver, event, bool, ["true"], ["(true,false,true)"]);
 

--- a/falco_plugin_tests/tests/extract_types.rs
+++ b/falco_plugin_tests/tests/extract_types.rs
@@ -248,52 +248,50 @@ impl ExtractPlugin for DummyPlugin {
 
 static_plugin!(DUMMY_PLUGIN_API = DummyPlugin);
 
+macro_rules! assert_field_variant_eq {
+    ($driver:expr, $event:expr, $field_name:expr, $expected:expr) => {
+        let actual = $driver
+            .event_field_as_string(c_str_macro::c_str!($field_name), &$event)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            $expected, actual,
+            "expected {:?} from {}, got {:?}",
+            $expected, $field_name, actual
+        );
+    };
+}
+
 macro_rules! assert_field_eq {
     ($driver:expr, $event:expr, $field_name:ident, $expected_val_expr:expr,
         $expected_vec_expr:expr) => {
-        assert_eq!(
-            $driver
-                .event_field_as_string(
-                    c_str_macro::c_str!(concat!("dummy.", stringify!($field_name))),
-                    &$event
-                )
-                .unwrap()
-                .unwrap(),
-            $expected_val_expr,
+        assert_field_variant_eq!(
+            $driver,
+            $event,
+            concat!("dummy.", stringify!($field_name)),
+            $expected_val_expr
         );
-        assert_eq!(
-            $driver
-                .event_field_as_string(
-                    c_str_macro::c_str!(concat!("dummy.", stringify!($field_name), "_opt")),
-                    &$event
-                )
-                .unwrap()
-                .unwrap(),
-            $expected_val_expr,
+        assert_field_variant_eq!(
+            $driver,
+            $event,
+            concat!("dummy.", stringify!($field_name), "_opt"),
+            $expected_val_expr
         );
         assert!($driver.event_field_is_none(
             c_str_macro::c_str!(concat!("dummy.", stringify!($field_name), "_opt_none")),
             &$event
         ));
-        assert_eq!(
-            $driver
-                .event_field_as_string(
-                    c_str_macro::c_str!(concat!("dummy.vec_", stringify!($field_name))),
-                    &$event
-                )
-                .unwrap()
-                .unwrap(),
-            $expected_vec_expr,
+        assert_field_variant_eq!(
+            $driver,
+            $event,
+            concat!("dummy.vec_", stringify!($field_name)),
+            $expected_vec_expr
         );
-        assert_eq!(
-            $driver
-                .event_field_as_string(
-                    c_str_macro::c_str!(concat!("dummy.vec_", stringify!($field_name), "_opt")),
-                    &$event
-                )
-                .unwrap()
-                .unwrap(),
-            $expected_vec_expr,
+        assert_field_variant_eq!(
+            $driver,
+            $event,
+            concat!("dummy.vec_", stringify!($field_name), "_opt"),
+            $expected_vec_expr
         );
         assert!($driver.event_field_is_none(
             c_str_macro::c_str!(concat!("dummy.vec_", stringify!($field_name), "_opt_none")),

--- a/falco_plugin_tests/tests/extract_types.rs
+++ b/falco_plugin_tests/tests/extract_types.rs
@@ -271,16 +271,10 @@ macro_rules! assert_field_eq {
                 .unwrap(),
             $expected_val_expr,
         );
-        assert_eq!(
-            $driver
-                .event_field_as_string(
-                    c_str_macro::c_str!(concat!("dummy.", stringify!($field_name), "_opt_none")),
-                    &$event
-                )
-                .unwrap()
-                .unwrap(),
-            "<NA>",
-        );
+        assert!($driver.event_field_is_none(
+            c_str_macro::c_str!(concat!("dummy.", stringify!($field_name), "_opt_none")),
+            &$event
+        ));
         assert_eq!(
             $driver
                 .event_field_as_string(
@@ -301,20 +295,10 @@ macro_rules! assert_field_eq {
                 .unwrap(),
             $expected_vec_expr,
         );
-        assert_eq!(
-            $driver
-                .event_field_as_string(
-                    c_str_macro::c_str!(concat!(
-                        "dummy.vec_",
-                        stringify!($field_name),
-                        "_opt_none"
-                    )),
-                    &$event
-                )
-                .unwrap()
-                .unwrap(),
-            "<NA>",
-        );
+        assert!($driver.event_field_is_none(
+            c_str_macro::c_str!(concat!("dummy.vec_", stringify!($field_name), "_opt_none")),
+            &$event
+        ));
     };
 }
 
@@ -358,11 +342,7 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(s == "10000000" || s == "10ms");
-        let s = driver
-            .event_field_as_string(c"dummy.reltime_opt_none", &event)
-            .unwrap()
-            .unwrap();
-        assert_eq!(s, "<NA>");
+        assert!(driver.event_field_is_none(c"dummy.reltime_opt_none", &event));
         let s = driver
             .event_field_as_string(c"dummy.vec_reltime", &event)
             .unwrap()
@@ -373,11 +353,7 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(s == "(10000000,20000000,30000000)" || s == "(10ms,20ms,30ms)");
-        let s = driver
-            .event_field_as_string(c"dummy.vec_reltime_opt_none", &event)
-            .unwrap()
-            .unwrap();
-        assert_eq!(s, "<NA>");
+        assert!(driver.event_field_is_none(c"dummy.vec_reltime_opt_none", &event));
 
         let ts_10ms = epoch_offset_to_rfc3389(Duration::from_millis(10));
         let ts_20ms = epoch_offset_to_rfc3389(Duration::from_millis(20));
@@ -392,11 +368,7 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(s == "10000000" || s == ts_10ms);
-        let s = driver
-            .event_field_as_string(c"dummy.abstime_opt_none", &event)
-            .unwrap()
-            .unwrap();
-        assert_eq!(s, "<NA>");
+        assert!(driver.event_field_is_none(c"dummy.abstime_opt_none", &event));
         let timestamps = format!("({ts_10ms},{ts_20ms},{ts_30ms})");
         let s = driver
             .event_field_as_string(c"dummy.vec_abstime", &event)
@@ -408,11 +380,7 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(s == "(10000000,20000000,30000000)" || s == timestamps);
-        let s = driver
-            .event_field_as_string(c"dummy.vec_abstime_opt_none", &event)
-            .unwrap()
-            .unwrap();
-        assert_eq!(s, "<NA>");
+        assert!(driver.event_field_is_none(c"dummy.vec_abstime_opt_none", &event));
 
         assert_field_eq!(driver, event, bool, "true", "(true,false,true)");
 

--- a/falco_plugin_tests/tests/extract_types.rs
+++ b/falco_plugin_tests/tests/extract_types.rs
@@ -250,14 +250,17 @@ static_plugin!(DUMMY_PLUGIN_API = DummyPlugin);
 
 macro_rules! assert_field_variant_eq {
     ($driver:expr, $event:expr, $field_name:expr, $expected:expr) => {
+        let expected = $expected.as_slice();
         let actual = $driver
             .event_field_as_string(c_str_macro::c_str!($field_name), &$event)
             .unwrap()
             .unwrap();
-        assert_eq!(
-            $expected, actual,
-            "expected {:?} from {}, got {:?}",
-            $expected, $field_name, actual
+        assert!(
+            expected.contains(&actual.as_str()),
+            "expected one of {:?} from {}, got {:?}",
+            $expected,
+            $field_name,
+            actual
         );
     };
 }
@@ -320,14 +323,14 @@ mod tests {
 
         let event = driver.next_event().unwrap();
 
-        assert_field_eq!(driver, event, u64, "5", "(5,6,7)");
+        assert_field_eq!(driver, event, u64, ["5"], ["(5,6,7)"]);
 
         assert_field_eq!(
             driver,
             event,
             string,
-            "Hello, World!",
-            "(Hello, World!,Hello, World!,Hello, World!)"
+            ["Hello, World!"],
+            ["(Hello, World!,Hello, World!,Hello, World!)"]
         );
 
         let s = driver
@@ -380,31 +383,31 @@ mod tests {
         assert!(s == "(10000000,20000000,30000000)" || s == timestamps);
         assert!(driver.event_field_is_none(c"dummy.vec_abstime_opt_none", &event));
 
-        assert_field_eq!(driver, event, bool, "true", "(true,false,true)");
+        assert_field_eq!(driver, event, bool, ["true"], ["(true,false,true)"]);
 
         assert_field_eq!(
             driver,
             event,
             ipaddr_v4,
-            "127.0.0.1",
-            "(127.0.0.1,255.255.255.255,0.0.0.0)"
+            ["127.0.0.1"],
+            ["(127.0.0.1,255.255.255.255,0.0.0.0)"]
         );
 
-        assert_field_eq!(driver, event, ipaddr_v6, "::1", "(::1,::)");
+        assert_field_eq!(driver, event, ipaddr_v6, ["::1"], ["(::1,::)"]);
 
-        assert_field_eq!(driver, event, ipaddr, "127.0.0.1", "(127.0.0.1,::)");
+        assert_field_eq!(driver, event, ipaddr, ["127.0.0.1"], ["(127.0.0.1,::)"]);
 
         assert_field_eq!(
             driver,
             event,
             ipnet_v4,
-            "<IPNET>",
-            "(<IPNET>,<IPNET>,<IPNET>)"
+            ["<IPNET>"],
+            ["(<IPNET>,<IPNET>,<IPNET>)"]
         );
 
-        assert_field_eq!(driver, event, ipnet_v6, "<IPNET>", "(<IPNET>,<IPNET>)");
+        assert_field_eq!(driver, event, ipnet_v6, ["<IPNET>"], ["(<IPNET>,<IPNET>)"]);
 
-        assert_field_eq!(driver, event, ipnet, "<IPNET>", "(<IPNET>,<IPNET>)");
+        assert_field_eq!(driver, event, ipnet, ["<IPNET>"], ["(<IPNET>,<IPNET>)"]);
     }
 
     instantiate_tests!(test_dummy_next);


### PR DESCRIPTION
`sinsp` does not distinguish between a failed extraction and a successful one that does not return any data. Our wrapper (c++/sinsp_test_driver.cpp) then considers "no result" from sinsp an error, so we treat that error as an indicator of extracting a None value.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area ci

> /area event

> /area event_derive

> /area plugin

> /area plugin_api

> /area plugin_derive

/area plugin_tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
NONE
```