### PR TITLE
cleanup(event): remove the Borrowed trait

### DIFF
--- a/falco_event/src/lib.rs
+++ b/falco_event/src/lib.rs
@@ -47,7 +47,6 @@ mod event_derive {
 
     pub use crate::types::Borrow;
     pub use crate::types::BorrowDeref;
-    pub use crate::types::Borrowed;
 
     #[cfg(feature = "serde")]
     pub use crate::types::serde;

--- a/falco_event/src/types/bytebuf.rs
+++ b/falco_event/src/types/bytebuf.rs
@@ -1,6 +1,6 @@
 use crate::fields::{FromBytes, FromBytesResult, ToBytes};
 use crate::types::format::{format_type, Format};
-use crate::types::{Borrow, BorrowDeref, Borrowed};
+use crate::types::{Borrow, BorrowDeref};
 use std::fmt::{Formatter, Write as _};
 use std::io::Write;
 
@@ -60,10 +60,6 @@ impl Format<format_type::PF_HEX> for &[u8] {
 
         Ok(())
     }
-}
-
-impl Borrowed for [u8] {
-    type Owned = Vec<u8>;
 }
 
 impl Borrow for Vec<u8> {

--- a/falco_event/src/types/mod.rs
+++ b/falco_event/src/types/mod.rs
@@ -31,6 +31,5 @@ pub use fd_list::*;
 pub use net::*;
 pub use owned::Borrow;
 pub use owned::BorrowDeref;
-pub use owned::Borrowed;
 pub use path::*;
 pub use primitive::*;

--- a/falco_event/src/types/net/sockaddr.rs
+++ b/falco_event/src/types/net/sockaddr.rs
@@ -1,7 +1,7 @@
 use crate::event_derive::{FromBytes, FromBytesResult, ToBytes};
 use crate::ffi::{PPM_AF_INET, PPM_AF_INET6, PPM_AF_LOCAL, PPM_AF_UNSPEC};
 use crate::types::format::Format;
-use crate::types::{Borrow, Borrowed, EndpointV4, EndpointV6};
+use crate::types::{Borrow, EndpointV4, EndpointV6};
 use byteorder::{ReadBytesExt, WriteBytesExt};
 use std::fmt::Formatter;
 use std::io::Write;
@@ -129,10 +129,6 @@ pub enum OwnedSockAddr {
         u8,
         #[cfg_attr(feature = "serde", serde(with = "crate::types::serde::bytebuf"))] Vec<u8>,
     ),
-}
-
-impl Borrowed for SockAddr<'_> {
-    type Owned = OwnedSockAddr;
 }
 
 impl Borrow for OwnedSockAddr {

--- a/falco_event/src/types/net/socktuple.rs
+++ b/falco_event/src/types/net/socktuple.rs
@@ -5,7 +5,7 @@ use crate::ffi::{PPM_AF_INET, PPM_AF_INET6, PPM_AF_LOCAL};
 use crate::fields::{FromBytes, FromBytesResult, ToBytes};
 use crate::types::format::Format;
 use crate::types::net::endpoint::{EndpointV4, EndpointV6};
-use crate::types::{Borrow, Borrowed};
+use crate::types::Borrow;
 use byteorder::{ReadBytesExt, WriteBytesExt};
 use typed_path::{UnixPath, UnixPathBuf};
 
@@ -213,10 +213,6 @@ pub enum OwnedSockTuple {
         u8,
         #[cfg_attr(feature = "serde", serde(with = "crate::types::serde::bytebuf"))] Vec<u8>,
     ),
-}
-
-impl Borrowed for SockTuple<'_> {
-    type Owned = OwnedSockTuple;
 }
 
 impl Borrow for OwnedSockTuple {

--- a/falco_event/src/types/owned.rs
+++ b/falco_event/src/types/owned.rs
@@ -1,15 +1,6 @@
-/// Trait implemented for borrowed event types
-///
-/// Similar to [`std::borrow::ToOwned`], but different because:
-/// 1. We don't have a to_owned method (we don't need it)
-/// 2. The borrowed type does not need to be a reference
-pub trait Borrowed {
-    type Owned;
-}
-
 /// Trait implemented for owned event types
 ///
-/// Similar to [`std::borrow::Borrow`], but again, different
+/// Similar to [`std::borrow::Borrow`], but different
 /// as the borrowed type does not need to be a reference
 pub trait Borrow {
     type Borrowed<'a>: Sized

--- a/falco_event/src/types/path/absolute_path.rs
+++ b/falco_event/src/types/path/absolute_path.rs
@@ -1,6 +1,6 @@
 use crate::event_derive::{FromBytes, FromBytesResult, ToBytes};
 use crate::types::format::Format;
-use crate::types::{Borrow, Borrowed};
+use crate::types::Borrow;
 use std::ffi::CStr;
 use std::fmt::Formatter;
 use std::io::Write;
@@ -36,10 +36,6 @@ where
         let bytes = self.as_bytes();
         bytes.format(fmt)
     }
-}
-
-impl Borrowed for UnixPath {
-    type Owned = UnixPathBuf;
 }
 
 impl Borrow for UnixPathBuf {

--- a/falco_event/src/types/path/relative_path.rs
+++ b/falco_event/src/types/path/relative_path.rs
@@ -1,6 +1,6 @@
 use crate::event_derive::{FromBytes, FromBytesResult, ToBytes};
 use crate::types::format::Format;
-use crate::types::{Borrow, Borrowed};
+use crate::types::Borrow;
 use std::fmt::Formatter;
 use std::io::Write;
 use typed_path::{UnixPath, UnixPathBuf};
@@ -57,10 +57,6 @@ where
 pub struct OwnedRelativePath(
     #[cfg_attr(feature = "serde", serde(with = "crate::types::serde::unix_path"))] pub UnixPathBuf,
 );
-
-impl Borrowed for RelativePath<'_> {
-    type Owned = OwnedRelativePath;
-}
 
 impl Borrow for OwnedRelativePath {
     type Borrowed<'b> = RelativePath<'b>;

--- a/falco_event/src/types/primitive/integers.rs
+++ b/falco_event/src/types/primitive/integers.rs
@@ -1,6 +1,6 @@
 use crate::fields::{FromBytes, FromBytesResult, ToBytes};
 use crate::types::format::{format_type, Format};
-use crate::types::{BorrowDeref, Borrowed};
+use crate::types::BorrowDeref;
 use byteorder::{ReadBytesExt, WriteBytesExt};
 
 macro_rules! impl_format {
@@ -33,10 +33,6 @@ macro_rules! impl_format {
 
 macro_rules! impl_borrow_deref {
     ($ty:ty) => {
-        impl Borrowed for $ty {
-            type Owned = Self;
-        }
-
         impl BorrowDeref for $ty {
             type Target<'a> = Self;
 

--- a/falco_event/src/types/primitive/newtypes.rs
+++ b/falco_event/src/types/primitive/newtypes.rs
@@ -1,7 +1,7 @@
 use crate::event_derive::format_type;
 use crate::fields::{FromBytes, FromBytesResult, ToBytes};
 use crate::types::format::Format;
-use crate::types::{BorrowDeref, Borrowed};
+use crate::types::BorrowDeref;
 use std::fmt::{Debug, Formatter};
 
 macro_rules! default_format {
@@ -46,10 +46,6 @@ macro_rules! newtype {
             fn default_repr() -> impl ToBytes {
                 <$repr>::default_repr()
             }
-        }
-
-        impl Borrowed for $name {
-            type Owned = Self;
         }
 
         impl BorrowDeref for $name {

--- a/falco_event/src/types/string/cstr.rs
+++ b/falco_event/src/types/string/cstr.rs
@@ -1,6 +1,6 @@
 use crate::event_derive::{FromBytes, FromBytesError, FromBytesResult, ToBytes};
 use crate::types::format::Format;
-use crate::types::{Borrow, Borrowed};
+use crate::types::Borrow;
 use std::ffi::{CStr, CString};
 use std::fmt::Formatter;
 use std::io::Write;
@@ -36,10 +36,6 @@ where
         let bytes = self.to_bytes();
         bytes.format(fmt)
     }
-}
-
-impl Borrowed for CStr {
-    type Owned = CString;
 }
 
 impl Borrow for CString {

--- a/falco_event/src/types/string/cstr_array.rs
+++ b/falco_event/src/types/string/cstr_array.rs
@@ -1,6 +1,6 @@
 use crate::event_derive::{FromBytes, FromBytesResult, ToBytes};
 use crate::types::format::Format;
-use crate::types::{Borrow, Borrowed};
+use crate::types::Borrow;
 use std::ffi::{CStr, CString};
 use std::fmt::{Formatter, Write as _};
 use std::io::Write;
@@ -51,10 +51,6 @@ where
 
         Ok(())
     }
-}
-
-impl Borrowed for Vec<&CStr> {
-    type Owned = Vec<CString>;
 }
 
 impl Borrow for Vec<CString> {

--- a/falco_event/src/types/string/cstr_pair_array.rs
+++ b/falco_event/src/types/string/cstr_pair_array.rs
@@ -1,6 +1,6 @@
 use crate::event_derive::{FromBytes, FromBytesError, FromBytesResult, ToBytes};
 use crate::types::format::Format;
-use crate::types::{Borrow, Borrowed};
+use crate::types::Borrow;
 use std::ffi::{CStr, CString};
 use std::fmt::{Formatter, Write as _};
 use std::io::Write;
@@ -62,10 +62,6 @@ where
 
         Ok(())
     }
-}
-
-impl<'a> Borrowed for Vec<(&'a CStr, &'a CStr)> {
-    type Owned = Vec<(CString, CString)>;
 }
 
 impl Borrow for Vec<(CString, CString)> {

--- a/falco_event/src/types/time/duration.rs
+++ b/falco_event/src/types/time/duration.rs
@@ -1,6 +1,6 @@
 use crate::event_derive::{FromBytes, FromBytesResult, ToBytes};
 use crate::types::format::Format;
-use crate::types::{BorrowDeref, Borrowed};
+use crate::types::BorrowDeref;
 use byteorder::{NativeEndian, ReadBytesExt};
 use std::fmt::Formatter;
 use std::io::Write;
@@ -33,10 +33,6 @@ impl<F> Format<F> for Duration {
     fn format(&self, fmt: &mut Formatter) -> std::fmt::Result {
         std::fmt::Debug::fmt(self, fmt)
     }
-}
-
-impl Borrowed for Duration {
-    type Owned = Self;
 }
 
 impl BorrowDeref for Duration {

--- a/falco_event/src/types/time/system_time.rs
+++ b/falco_event/src/types/time/system_time.rs
@@ -1,6 +1,5 @@
 use crate::event_derive::{FromBytes, FromBytesResult, ToBytes};
 use crate::types::format::Format;
-use crate::types::Borrowed;
 use chrono::Local;
 use std::fmt::Formatter;
 use std::io::Write;
@@ -31,10 +30,6 @@ impl ToBytes for SystemTime {
     fn default_repr() -> impl ToBytes {
         0u64
     }
-}
-
-impl Borrowed for SystemTime {
-    type Owned = Self;
 }
 
 impl<F> Format<F> for SystemTime {

--- a/falco_event_derive/src/event_flags.rs
+++ b/falco_event_derive/src/event_flags.rs
@@ -196,10 +196,6 @@ fn render_enum(
             }
         }
 
-        impl crate::event_derive::Borrowed for #name {
-            type Owned = Self;
-        }
-
         impl<F> crate::event_derive::Format<F> for #name
         where
             #repr_type: crate::event_derive::Format<F>,
@@ -266,10 +262,6 @@ fn render_bitflags(
                 let val = Self::from_bits_retain(repr);
                 Ok(val)
             }
-        }
-
-        impl crate::event_derive::Borrowed for #name {
-            type Owned = Self;
         }
 
         impl<F> crate::event_derive::Format<F> for #name {

--- a/falco_event_derive/src/event_info.rs
+++ b/falco_event_derive/src/event_info.rs
@@ -96,29 +96,26 @@ impl EventArg {
     ) -> (
         Option<proc_macro2::TokenStream>,
         Option<proc_macro2::TokenStream>,
-        Option<proc_macro2::TokenStream>,
     ) {
         let field_type = self.final_field_type_name();
 
         match lifetime_type(&field_type.to_string()) {
-            LifetimeType::Ref => (Some(quote!(&'a)), None, None),
-            LifetimeType::Generic => (None, Some(quote!(<'a>)), Some(quote!(<'static>))),
-            LifetimeType::None => (None, None, None),
+            LifetimeType::Ref => (Some(quote!(&'a)), None),
+            LifetimeType::Generic => (None, Some(quote!(<'a>))),
+            LifetimeType::None => (None, None),
         }
     }
 
     fn field_type(&self, variant: CodegenVariant) -> proc_macro2::TokenStream {
         let field_type = self.final_field_type_name();
-        let (field_ref, field_lifetime, static_field_lifetime) = self.lifetimes();
+        let (field_ref, field_lifetime) = self.lifetimes();
 
         match variant {
             CodegenVariant::Borrowed => {
                 quote!(::std::option::Option<#field_ref crate::event_derive::event_field_type::#field_type #field_lifetime>)
             }
             CodegenVariant::Owned => {
-                quote!(::std::option::Option<
-                    <crate::event_derive::event_field_type::#field_type #static_field_lifetime as
-                    crate::event_derive::Borrowed>::Owned>)
+                quote!(::std::option::Option<crate::event_derive::event_field_type::owned::#field_type>)
             }
         }
     }


### PR DESCRIPTION
The purpose of this trait was to get from a borrowed type to an owned type. The only use was to figure out the right type for the owned variants' fields, but since we already have a whole module with the owned types, just use that directly.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area ci

/area event

> /area event_derive

> /area plugin

> /area plugin_api

> /area plugin_derive

> /area plugin_tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
NONE
```