### PR TITLE
cleanup(event): Remove event_derive module

### DIFF
--- a/falco_event/src/events/event.rs
+++ b/falco_event/src/events/event.rs
@@ -1,5 +1,5 @@
-use crate::event_derive::{EventMetadata, PayloadToBytes};
 use crate::events::to_bytes::EventToBytes;
+use crate::events::{EventMetadata, PayloadToBytes};
 use std::fmt::{Debug, Formatter};
 use std::io::Write;
 

--- a/falco_event/src/events/mod.rs
+++ b/falco_event/src/events/mod.rs
@@ -3,6 +3,7 @@ pub use metadata::EventMetadata;
 pub use payload::EventDirection;
 pub use payload::EventPayload;
 pub use payload::PayloadFromBytes;
+pub use payload::PayloadFromBytesError;
 pub use payload::PayloadToBytes;
 pub use raw_event::RawEvent;
 pub use to_bytes::EventToBytes;

--- a/falco_event/src/lib.rs
+++ b/falco_event/src/lib.rs
@@ -30,7 +30,6 @@ mod event_derive {
     pub use crate::events::PayloadFromBytes;
     pub use crate::events::RawEvent;
     pub use crate::fields::FromBytesError;
-    pub use crate::fields::ToBytes;
     pub use crate::types::format::OptionFormatter;
     pub use crate::types::ByteBufFormatter;
     pub use crate::types::CStrArrayFormatter;

--- a/falco_event/src/lib.rs
+++ b/falco_event/src/lib.rs
@@ -29,7 +29,6 @@ mod event_derive {
     pub use crate::events::Event;
     pub use crate::events::PayloadFromBytes;
     pub use crate::events::RawEvent;
-    pub use crate::fields::FromBytesError;
     pub use crate::types::format::OptionFormatter;
     pub use crate::types::ByteBufFormatter;
     pub use crate::types::CStrArrayFormatter;

--- a/falco_event/src/lib.rs
+++ b/falco_event/src/lib.rs
@@ -33,7 +33,6 @@ mod event_derive {
     pub use crate::events::payload::PayloadFromBytesError;
     pub use crate::events::payload::PayloadFromBytesResult;
     pub use crate::events::Event;
-    pub use crate::events::EventDirection;
     pub use crate::events::EventMetadata;
     pub use crate::events::PayloadFromBytes;
     pub use crate::events::PayloadToBytes;

--- a/falco_event/src/lib.rs
+++ b/falco_event/src/lib.rs
@@ -36,6 +36,5 @@ pub mod ffi;
 
 // things for the derive macro to access under a well-known name
 mod event_derive {
-    pub use byteorder::ReadBytesExt;
     pub use byteorder::WriteBytesExt;
 }

--- a/falco_event/src/lib.rs
+++ b/falco_event/src/lib.rs
@@ -37,7 +37,6 @@ pub mod ffi;
 
 // things for the derive macro to access under a well-known name
 mod event_derive {
-    pub use crate::events::Event;
     pub use crate::events::PayloadFromBytes;
     pub use crate::events::RawEvent;
     pub use crate::types::SystemTimeFormatter;

--- a/falco_event/src/lib.rs
+++ b/falco_event/src/lib.rs
@@ -33,8 +33,3 @@ pub mod format {
 #[allow(unsafe_op_in_unsafe_fn)]
 #[doc(hidden)]
 pub mod ffi;
-
-// things for the derive macro to access under a well-known name
-mod event_derive {
-    pub use byteorder::WriteBytesExt;
-}

--- a/falco_event/src/lib.rs
+++ b/falco_event/src/lib.rs
@@ -28,7 +28,6 @@ pub mod ffi;
 mod event_derive {
     pub use crate::events::Event;
     pub use crate::events::PayloadFromBytes;
-    pub use crate::events::PayloadToBytes;
     pub use crate::events::RawEvent;
     pub use crate::fields::FromBytes;
     pub use crate::fields::FromBytesError;

--- a/falco_event/src/lib.rs
+++ b/falco_event/src/lib.rs
@@ -30,7 +30,6 @@ mod event_derive {
     pub use crate::events::PayloadFromBytes;
     pub use crate::events::RawEvent;
     pub use crate::fields::FromBytesError;
-    pub use crate::fields::FromBytesResult;
     pub use crate::fields::NoDefault;
     pub use crate::fields::ToBytes;
     pub use crate::types::format::OptionFormatter;

--- a/falco_event/src/lib.rs
+++ b/falco_event/src/lib.rs
@@ -35,7 +35,6 @@ mod event_derive {
     pub use crate::events::Event;
     pub use crate::events::EventDirection;
     pub use crate::events::EventMetadata;
-    pub use crate::events::EventPayload;
     pub use crate::events::PayloadFromBytes;
     pub use crate::events::PayloadToBytes;
     pub use crate::events::RawEvent;

--- a/falco_event/src/lib.rs
+++ b/falco_event/src/lib.rs
@@ -21,6 +21,7 @@ pub mod format {
     pub use crate::types::ByteBufFormatter;
     pub use crate::types::CStrArrayFormatter;
     pub use crate::types::CStrFormatter;
+    pub use crate::types::CStrPairArrayFormatter;
 }
 
 pub use crate::types::SystemTimeFormatter;
@@ -39,7 +40,6 @@ mod event_derive {
     pub use crate::events::Event;
     pub use crate::events::PayloadFromBytes;
     pub use crate::events::RawEvent;
-    pub use crate::types::CStrPairArrayFormatter;
     pub use crate::types::SystemTimeFormatter;
     pub use byteorder::NativeEndian;
     pub use byteorder::ReadBytesExt;

--- a/falco_event/src/lib.rs
+++ b/falco_event/src/lib.rs
@@ -29,7 +29,6 @@ mod event_derive {
     pub use crate::events::Event;
     pub use crate::events::PayloadFromBytes;
     pub use crate::events::RawEvent;
-    pub use crate::fields::FromBytes;
     pub use crate::fields::FromBytesError;
     pub use crate::fields::FromBytesResult;
     pub use crate::fields::NoDefault;

--- a/falco_event/src/lib.rs
+++ b/falco_event/src/lib.rs
@@ -26,12 +26,6 @@ pub mod ffi;
 
 // things for the derive macro to access under a well-known name
 mod event_derive {
-    pub use byteorder::NativeEndian;
-    pub use byteorder::ReadBytesExt;
-    pub use byteorder::WriteBytesExt;
-
-    pub use crate::events::payload::PayloadFromBytesError;
-    pub use crate::events::payload::PayloadFromBytesResult;
     pub use crate::events::Event;
     pub use crate::events::PayloadFromBytes;
     pub use crate::events::PayloadToBytes;
@@ -47,4 +41,7 @@ mod event_derive {
     pub use crate::types::CStrFormatter;
     pub use crate::types::CStrPairArrayFormatter;
     pub use crate::types::SystemTimeFormatter;
+    pub use byteorder::NativeEndian;
+    pub use byteorder::ReadBytesExt;
+    pub use byteorder::WriteBytesExt;
 }

--- a/falco_event/src/lib.rs
+++ b/falco_event/src/lib.rs
@@ -30,7 +30,6 @@ mod event_derive {
     pub use crate::events::PayloadFromBytes;
     pub use crate::events::RawEvent;
     pub use crate::fields::FromBytesError;
-    pub use crate::fields::NoDefault;
     pub use crate::fields::ToBytes;
     pub use crate::types::format::OptionFormatter;
     pub use crate::types::ByteBufFormatter;

--- a/falco_event/src/lib.rs
+++ b/falco_event/src/lib.rs
@@ -36,7 +36,6 @@ pub mod ffi;
 
 // things for the derive macro to access under a well-known name
 mod event_derive {
-    pub use byteorder::NativeEndian;
     pub use byteorder::ReadBytesExt;
     pub use byteorder::WriteBytesExt;
 }

--- a/falco_event/src/lib.rs
+++ b/falco_event/src/lib.rs
@@ -37,7 +37,6 @@ pub mod ffi;
 
 // things for the derive macro to access under a well-known name
 mod event_derive {
-    pub use crate::events::PayloadFromBytes;
     pub use crate::events::RawEvent;
     pub use crate::types::SystemTimeFormatter;
     pub use byteorder::NativeEndian;

--- a/falco_event/src/lib.rs
+++ b/falco_event/src/lib.rs
@@ -12,8 +12,15 @@ pub mod events;
 pub mod fields;
 mod types;
 
-pub use types::format;
-pub use types::SystemTimeFormatter;
+/// Formatting wrappers
+///
+/// This module provides wrappers for various types that format the inner type according
+/// to Falco style.
+pub mod format {
+    pub use crate::types::format::OptionFormatter;
+}
+
+pub use crate::types::SystemTimeFormatter;
 
 #[allow(dead_code)]
 #[allow(non_snake_case)]
@@ -29,7 +36,6 @@ mod event_derive {
     pub use crate::events::Event;
     pub use crate::events::PayloadFromBytes;
     pub use crate::events::RawEvent;
-    pub use crate::types::format::OptionFormatter;
     pub use crate::types::ByteBufFormatter;
     pub use crate::types::CStrArrayFormatter;
     pub use crate::types::CStrFormatter;

--- a/falco_event/src/lib.rs
+++ b/falco_event/src/lib.rs
@@ -19,6 +19,7 @@ mod types;
 pub mod format {
     pub use crate::types::format::OptionFormatter;
     pub use crate::types::ByteBufFormatter;
+    pub use crate::types::CStrArrayFormatter;
 }
 
 pub use crate::types::SystemTimeFormatter;
@@ -37,7 +38,6 @@ mod event_derive {
     pub use crate::events::Event;
     pub use crate::events::PayloadFromBytes;
     pub use crate::events::RawEvent;
-    pub use crate::types::CStrArrayFormatter;
     pub use crate::types::CStrFormatter;
     pub use crate::types::CStrPairArrayFormatter;
     pub use crate::types::SystemTimeFormatter;

--- a/falco_event/src/lib.rs
+++ b/falco_event/src/lib.rs
@@ -18,6 +18,7 @@ mod types;
 /// to Falco style.
 pub mod format {
     pub use crate::types::format::OptionFormatter;
+    pub use crate::types::ByteBufFormatter;
 }
 
 pub use crate::types::SystemTimeFormatter;
@@ -36,7 +37,6 @@ mod event_derive {
     pub use crate::events::Event;
     pub use crate::events::PayloadFromBytes;
     pub use crate::events::RawEvent;
-    pub use crate::types::ByteBufFormatter;
     pub use crate::types::CStrArrayFormatter;
     pub use crate::types::CStrFormatter;
     pub use crate::types::CStrPairArrayFormatter;

--- a/falco_event/src/lib.rs
+++ b/falco_event/src/lib.rs
@@ -33,7 +33,6 @@ mod event_derive {
     pub use crate::events::payload::PayloadFromBytesError;
     pub use crate::events::payload::PayloadFromBytesResult;
     pub use crate::events::Event;
-    pub use crate::events::EventMetadata;
     pub use crate::events::PayloadFromBytes;
     pub use crate::events::PayloadToBytes;
     pub use crate::events::RawEvent;

--- a/falco_event/src/lib.rs
+++ b/falco_event/src/lib.rs
@@ -20,6 +20,7 @@ pub mod format {
     pub use crate::types::format::OptionFormatter;
     pub use crate::types::ByteBufFormatter;
     pub use crate::types::CStrArrayFormatter;
+    pub use crate::types::CStrFormatter;
 }
 
 pub use crate::types::SystemTimeFormatter;
@@ -38,7 +39,6 @@ mod event_derive {
     pub use crate::events::Event;
     pub use crate::events::PayloadFromBytes;
     pub use crate::events::RawEvent;
-    pub use crate::types::CStrFormatter;
     pub use crate::types::CStrPairArrayFormatter;
     pub use crate::types::SystemTimeFormatter;
     pub use byteorder::NativeEndian;

--- a/falco_event/src/lib.rs
+++ b/falco_event/src/lib.rs
@@ -22,9 +22,8 @@ pub mod format {
     pub use crate::types::CStrArrayFormatter;
     pub use crate::types::CStrFormatter;
     pub use crate::types::CStrPairArrayFormatter;
+    pub use crate::types::SystemTimeFormatter;
 }
-
-pub use crate::types::SystemTimeFormatter;
 
 #[allow(dead_code)]
 #[allow(non_snake_case)]
@@ -37,7 +36,6 @@ pub mod ffi;
 
 // things for the derive macro to access under a well-known name
 mod event_derive {
-    pub use crate::types::SystemTimeFormatter;
     pub use byteorder::NativeEndian;
     pub use byteorder::ReadBytesExt;
     pub use byteorder::WriteBytesExt;

--- a/falco_event/src/lib.rs
+++ b/falco_event/src/lib.rs
@@ -37,7 +37,6 @@ pub mod ffi;
 
 // things for the derive macro to access under a well-known name
 mod event_derive {
-    pub use crate::events::RawEvent;
     pub use crate::types::SystemTimeFormatter;
     pub use byteorder::NativeEndian;
     pub use byteorder::ReadBytesExt;

--- a/falco_event/src/types/bytebuf.rs
+++ b/falco_event/src/types/bytebuf.rs
@@ -55,8 +55,7 @@ impl Debug for ByteBufFormatter<'_> {
 
 #[cfg(test)]
 mod tests {
-    use crate::fields::FromBytes;
-    use crate::fields::ToBytes;
+    use crate::fields::{FromBytes, ToBytes};
 
     #[test]
     fn test_bytebuf() {

--- a/falco_event/src/types/bytebuf.rs
+++ b/falco_event/src/types/bytebuf.rs
@@ -1,9 +1,9 @@
-use crate::fields::{FromBytes, FromBytesResult, ToBytes};
+use crate::fields::{FromBytes, FromBytesError, ToBytes};
 use std::fmt::{Debug, Formatter, Write as _};
 use std::io::Write;
 
 impl<'a> FromBytes<'a> for &'a [u8] {
-    fn from_bytes(buf: &mut &'a [u8]) -> FromBytesResult<Self> {
+    fn from_bytes(buf: &mut &'a [u8]) -> Result<Self, FromBytesError> {
         Ok(std::mem::take(buf))
     }
 }
@@ -55,7 +55,7 @@ impl Debug for ByteBufFormatter<'_> {
 
 #[cfg(test)]
 mod tests {
-    use crate::event_derive::{FromBytes, ToBytes};
+    use crate::fields::{FromBytes, ToBytes};
 
     #[test]
     fn test_bytebuf() {

--- a/falco_event/src/types/bytebuf.rs
+++ b/falco_event/src/types/bytebuf.rs
@@ -22,6 +22,12 @@ impl ToBytes for &[u8] {
     }
 }
 
+/// Falco-style byte buffer formatter
+///
+/// The default [`Debug`] impl prints out the buffer as an ASCII string, replacing non-printable
+/// characters with dots (`.`).
+///
+/// The hex debug implementation (`{:x?}`) generates a hex dump of the whole buffer.
 pub struct ByteBufFormatter<'a>(pub &'a [u8]);
 
 impl Debug for ByteBufFormatter<'_> {

--- a/falco_event/src/types/bytebuf.rs
+++ b/falco_event/src/types/bytebuf.rs
@@ -55,7 +55,8 @@ impl Debug for ByteBufFormatter<'_> {
 
 #[cfg(test)]
 mod tests {
-    use crate::fields::{FromBytes, ToBytes};
+    use crate::fields::FromBytes;
+    use crate::fields::ToBytes;
 
     #[test]
     fn test_bytebuf() {

--- a/falco_event/src/types/net/endpoint.rs
+++ b/falco_event/src/types/net/endpoint.rs
@@ -1,4 +1,4 @@
-use crate::event_derive::{FromBytes, FromBytesResult, ToBytes};
+use crate::fields::{FromBytes, FromBytesError, ToBytes};
 use crate::types::Port;
 use std::io::Write;
 use std::net::{Ipv4Addr, Ipv6Addr};
@@ -22,7 +22,7 @@ impl ToBytes for EndpointV4 {
 }
 
 impl FromBytes<'_> for EndpointV4 {
-    fn from_bytes(buf: &mut &'_ [u8]) -> FromBytesResult<Self> {
+    fn from_bytes(buf: &mut &'_ [u8]) -> Result<Self, FromBytesError> {
         Ok((FromBytes::from_bytes(buf)?, FromBytes::from_bytes(buf)?))
     }
 }
@@ -46,7 +46,7 @@ impl ToBytes for EndpointV6 {
 }
 
 impl FromBytes<'_> for EndpointV6 {
-    fn from_bytes(buf: &mut &'_ [u8]) -> FromBytesResult<Self> {
+    fn from_bytes(buf: &mut &'_ [u8]) -> Result<Self, FromBytesError> {
         Ok((FromBytes::from_bytes(buf)?, FromBytes::from_bytes(buf)?))
     }
 }

--- a/falco_event/src/types/net/ipaddr.rs
+++ b/falco_event/src/types/net/ipaddr.rs
@@ -1,9 +1,9 @@
-use crate::event_derive::{FromBytes, FromBytesError, FromBytesResult, ToBytes};
+use crate::fields::{FromBytes, FromBytesError, ToBytes};
 use std::io::Write;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 impl FromBytes<'_> for IpAddr {
-    fn from_bytes(buf: &mut &[u8]) -> FromBytesResult<Self> {
+    fn from_bytes(buf: &mut &[u8]) -> Result<Self, FromBytesError> {
         match buf.len() {
             4 => Ok(IpAddr::V4(Ipv4Addr::from_bytes(buf)?)),
             16 => Ok(IpAddr::V6(Ipv6Addr::from_bytes(buf)?)),

--- a/falco_event/src/types/net/ipnet.rs
+++ b/falco_event/src/types/net/ipnet.rs
@@ -1,4 +1,4 @@
-use crate::event_derive::{FromBytes, FromBytesResult, ToBytes};
+use crate::fields::{FromBytes, FromBytesError, ToBytes};
 use std::fmt::{Debug, Formatter};
 use std::io::Write;
 use std::net::IpAddr;
@@ -11,7 +11,7 @@ use std::net::IpAddr;
 pub struct IpNet(pub IpAddr);
 
 impl FromBytes<'_> for IpNet {
-    fn from_bytes(buf: &mut &[u8]) -> FromBytesResult<Self> {
+    fn from_bytes(buf: &mut &[u8]) -> Result<Self, FromBytesError> {
         Ok(Self(IpAddr::from_bytes(buf)?))
     }
 }

--- a/falco_event/src/types/net/ipnet.rs
+++ b/falco_event/src/types/net/ipnet.rs
@@ -1,4 +1,5 @@
-use crate::fields::{FromBytes, FromBytesError, ToBytes};
+use crate::fields::FromBytes;
+use crate::fields::{FromBytesError, ToBytes};
 use std::fmt::{Debug, Formatter};
 use std::io::Write;
 use std::net::IpAddr;

--- a/falco_event/src/types/net/ipv4addr.rs
+++ b/falco_event/src/types/net/ipv4addr.rs
@@ -1,12 +1,10 @@
+use crate::fields::{FromBytes, FromBytesError, ToBytes};
+use byteorder::{NetworkEndian, ReadBytesExt};
 use std::io::Write;
 use std::net::Ipv4Addr;
 
-use byteorder::{NetworkEndian, ReadBytesExt};
-
-use crate::fields::{FromBytes, FromBytesResult, ToBytes};
-
 impl FromBytes<'_> for Ipv4Addr {
-    fn from_bytes(buf: &mut &[u8]) -> FromBytesResult<Self> {
+    fn from_bytes(buf: &mut &[u8]) -> Result<Self, FromBytesError> {
         let bytes = buf.read_u32::<NetworkEndian>()?;
         Ok(bytes.into())
     }

--- a/falco_event/src/types/net/ipv4net.rs
+++ b/falco_event/src/types/net/ipv4net.rs
@@ -1,5 +1,4 @@
-use crate::event_derive::ToBytes;
-use crate::fields::{FromBytes, FromBytesError};
+use crate::fields::{FromBytes, FromBytesError, ToBytes};
 use std::fmt::{Debug, Formatter};
 use std::io::Write;
 use std::net::Ipv4Addr;

--- a/falco_event/src/types/net/ipv4net.rs
+++ b/falco_event/src/types/net/ipv4net.rs
@@ -1,4 +1,4 @@
-use crate::event_derive::{FromBytes, FromBytesResult, ToBytes};
+use crate::fields::{FromBytes, FromBytesError, ToBytes};
 use std::fmt::{Debug, Formatter};
 use std::io::Write;
 use std::net::Ipv4Addr;
@@ -11,7 +11,7 @@ use std::net::Ipv4Addr;
 pub struct Ipv4Net(pub Ipv4Addr);
 
 impl FromBytes<'_> for Ipv4Net {
-    fn from_bytes(buf: &mut &[u8]) -> FromBytesResult<Self> {
+    fn from_bytes(buf: &mut &[u8]) -> Result<Self, FromBytesError> {
         Ok(Self(Ipv4Addr::from_bytes(buf)?))
     }
 }

--- a/falco_event/src/types/net/ipv4net.rs
+++ b/falco_event/src/types/net/ipv4net.rs
@@ -1,4 +1,5 @@
-use crate::fields::{FromBytes, FromBytesError, ToBytes};
+use crate::event_derive::ToBytes;
+use crate::fields::{FromBytes, FromBytesError};
 use std::fmt::{Debug, Formatter};
 use std::io::Write;
 use std::net::Ipv4Addr;

--- a/falco_event/src/types/net/ipv6addr.rs
+++ b/falco_event/src/types/net/ipv6addr.rs
@@ -1,4 +1,5 @@
-use crate::fields::{FromBytes, FromBytesError, ToBytes};
+use crate::fields::FromBytes;
+use crate::fields::{FromBytesError, ToBytes};
 use std::io::{Read, Write};
 use std::net::Ipv6Addr;
 

--- a/falco_event/src/types/net/ipv6addr.rs
+++ b/falco_event/src/types/net/ipv6addr.rs
@@ -1,9 +1,9 @@
-use crate::event_derive::{FromBytes, FromBytesError, FromBytesResult, ToBytes};
+use crate::fields::{FromBytes, FromBytesError, ToBytes};
 use std::io::{Read, Write};
 use std::net::Ipv6Addr;
 
 impl FromBytes<'_> for Ipv6Addr {
-    fn from_bytes(buf: &mut &[u8]) -> FromBytesResult<Self> {
+    fn from_bytes(buf: &mut &[u8]) -> Result<Self, FromBytesError> {
         if buf.len() < 16 {
             return Err(FromBytesError::InvalidLength);
         }

--- a/falco_event/src/types/net/ipv6net.rs
+++ b/falco_event/src/types/net/ipv6net.rs
@@ -1,4 +1,4 @@
-use crate::event_derive::{FromBytes, FromBytesResult, ToBytes};
+use crate::fields::{FromBytes, FromBytesError, ToBytes};
 use std::fmt::{Debug, Formatter};
 use std::io::Write;
 use std::net::Ipv6Addr;
@@ -11,7 +11,7 @@ use std::net::Ipv6Addr;
 pub struct Ipv6Net(pub Ipv6Addr);
 
 impl FromBytes<'_> for Ipv6Net {
-    fn from_bytes(buf: &mut &[u8]) -> FromBytesResult<Self> {
+    fn from_bytes(buf: &mut &[u8]) -> Result<Self, FromBytesError> {
         Ok(Self(Ipv6Addr::from_bytes(buf)?))
     }
 }

--- a/falco_event/src/types/net/sockaddr.rs
+++ b/falco_event/src/types/net/sockaddr.rs
@@ -1,5 +1,5 @@
-use crate::event_derive::{FromBytes, FromBytesResult, ToBytes};
 use crate::ffi::{PPM_AF_INET, PPM_AF_INET6, PPM_AF_LOCAL, PPM_AF_UNSPEC};
+use crate::fields::{FromBytes, FromBytesError, ToBytes};
 use crate::types::{EndpointV4, EndpointV6};
 use byteorder::{ReadBytesExt, WriteBytesExt};
 use std::fmt::{Debug, Formatter};
@@ -58,7 +58,7 @@ impl ToBytes for SockAddr<'_> {
 }
 
 impl<'a> FromBytes<'a> for SockAddr<'a> {
-    fn from_bytes(buf: &mut &'a [u8]) -> FromBytesResult<Self> {
+    fn from_bytes(buf: &mut &'a [u8]) -> Result<Self, FromBytesError> {
         let variant = buf.read_u8()?;
         match variant as u32 {
             PPM_AF_LOCAL => {

--- a/falco_event/src/types/net/socktuple.rs
+++ b/falco_event/src/types/net/socktuple.rs
@@ -2,7 +2,7 @@ use std::fmt::{Debug, Formatter};
 use std::io::Write;
 
 use crate::ffi::{PPM_AF_INET, PPM_AF_INET6, PPM_AF_LOCAL};
-use crate::fields::{FromBytes, FromBytesResult, ToBytes};
+use crate::fields::{FromBytes, FromBytesError, ToBytes};
 use crate::types::net::endpoint::{EndpointV4, EndpointV6};
 use byteorder::{ReadBytesExt, WriteBytesExt};
 use typed_path::UnixPath;
@@ -116,7 +116,7 @@ impl ToBytes for SockTuple<'_> {
 }
 
 impl<'a> FromBytes<'a> for SockTuple<'a> {
-    fn from_bytes(buf: &mut &'a [u8]) -> FromBytesResult<Self> {
+    fn from_bytes(buf: &mut &'a [u8]) -> Result<Self, FromBytesError> {
         let variant = buf.read_u8()?;
         match variant as u32 {
             PPM_AF_LOCAL => Ok(Self::Unix {

--- a/falco_event/src/types/path/absolute_path.rs
+++ b/falco_event/src/types/path/absolute_path.rs
@@ -1,10 +1,10 @@
-use crate::event_derive::{FromBytes, FromBytesResult, ToBytes};
+use crate::fields::{FromBytes, FromBytesError, ToBytes};
 use std::ffi::CStr;
 use std::io::Write;
 use typed_path::UnixPath;
 
 impl<'a> FromBytes<'a> for &'a UnixPath {
-    fn from_bytes(buf: &mut &'a [u8]) -> FromBytesResult<Self> {
+    fn from_bytes(buf: &mut &'a [u8]) -> Result<Self, FromBytesError> {
         let buf = <&CStr>::from_bytes(buf)?;
         Ok(UnixPath::new(buf.to_bytes()))
     }
@@ -27,7 +27,7 @@ impl ToBytes for &UnixPath {
 
 #[cfg(test)]
 mod tests {
-    use crate::event_derive::{FromBytes, ToBytes};
+    use crate::fields::{FromBytes, ToBytes};
     use std::str::FromStr;
     use typed_path::{UnixPath, UnixPathBuf};
 

--- a/falco_event/src/types/path/relative_path.rs
+++ b/falco_event/src/types/path/relative_path.rs
@@ -1,4 +1,4 @@
-use crate::event_derive::{FromBytes, FromBytesResult, ToBytes};
+use crate::fields::{FromBytes, FromBytesError, ToBytes};
 use std::fmt::{Debug, Formatter};
 use std::io::Write;
 use typed_path::UnixPath;
@@ -25,7 +25,7 @@ impl<'a> ToBytes for RelativePath<'a> {
 }
 
 impl<'a> FromBytes<'a> for RelativePath<'a> {
-    fn from_bytes(buf: &mut &'a [u8]) -> FromBytesResult<Self> {
+    fn from_bytes(buf: &mut &'a [u8]) -> Result<Self, FromBytesError> {
         Ok(Self(<&'a UnixPath>::from_bytes(buf)?))
     }
 }
@@ -40,7 +40,7 @@ impl Debug for RelativePath<'_> {
 mod tests {
     use std::str::FromStr;
 
-    use crate::event_derive::{FromBytes, ToBytes};
+    use crate::fields::{FromBytes, ToBytes};
     use crate::types::path::relative_path::RelativePath;
 
     use typed_path::UnixPathBuf;

--- a/falco_event/src/types/primitive/bool.rs
+++ b/falco_event/src/types/primitive/bool.rs
@@ -1,9 +1,9 @@
-use crate::event_derive::{FromBytes, FromBytesResult, ToBytes};
+use crate::fields::{FromBytes, FromBytesError, ToBytes};
 use crate::types::primitive::bool;
 use std::io::Write;
 
 impl FromBytes<'_> for bool {
-    fn from_bytes(buf: &mut &[u8]) -> FromBytesResult<Self> {
+    fn from_bytes(buf: &mut &[u8]) -> Result<Self, FromBytesError> {
         let val = u32::from_bytes(buf)?;
         Ok(val != 0)
     }

--- a/falco_event/src/types/string/cstr.rs
+++ b/falco_event/src/types/string/cstr.rs
@@ -1,11 +1,11 @@
-use crate::event_derive::{FromBytes, FromBytesError, FromBytesResult, ToBytes};
+use crate::fields::{FromBytes, FromBytesError, ToBytes};
 use crate::types::ByteBufFormatter;
 use std::ffi::CStr;
 use std::fmt::{Debug, Formatter};
 use std::io::Write;
 
 impl<'a> FromBytes<'a> for &'a CStr {
-    fn from_bytes(buf: &mut &'a [u8]) -> FromBytesResult<Self> {
+    fn from_bytes(buf: &mut &'a [u8]) -> Result<Self, FromBytesError> {
         let cstr = CStr::from_bytes_until_nul(buf).map_err(|_| FromBytesError::MissingNul)?;
         let len = cstr.to_bytes().len();
         *buf = &buf[len + 1..];
@@ -37,7 +37,7 @@ impl Debug for CStrFormatter<'_> {
 
 #[cfg(test)]
 mod tests {
-    use crate::event_derive::{FromBytes, ToBytes};
+    use crate::fields::{FromBytes, ToBytes};
     use std::ffi::CStr;
 
     #[test]

--- a/falco_event/src/types/string/cstr.rs
+++ b/falco_event/src/types/string/cstr.rs
@@ -27,6 +27,10 @@ impl ToBytes for &CStr {
     }
 }
 
+/// Falco-style CStr formatter
+///
+/// Formats the string like a byte buffer (replacing non-ASCII characters with `.`).
+/// See [`ByteBufFormatter`] for the implementation.
 pub struct CStrFormatter<'a>(pub &'a CStr);
 
 impl Debug for CStrFormatter<'_> {

--- a/falco_event/src/types/string/cstr_array.rs
+++ b/falco_event/src/types/string/cstr_array.rs
@@ -1,4 +1,4 @@
-use crate::event_derive::{FromBytes, FromBytesResult, ToBytes};
+use crate::fields::{FromBytes, FromBytesError, ToBytes};
 use crate::types::CStrFormatter;
 use std::ffi::CStr;
 use std::fmt::{Debug, Formatter, Write as _};
@@ -23,7 +23,7 @@ impl ToBytes for Vec<&CStr> {
 }
 
 impl<'a> FromBytes<'a> for Vec<&'a CStr> {
-    fn from_bytes(buf: &mut &'a [u8]) -> FromBytesResult<Self> {
+    fn from_bytes(buf: &mut &'a [u8]) -> Result<Self, FromBytesError> {
         let mut data = Vec::new();
         while !buf.is_empty() {
             data.push(FromBytes::from_bytes(buf)?);
@@ -52,7 +52,7 @@ impl<T: AsRef<CStr>> Debug for CStrArrayFormatter<'_, T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::event_derive::{FromBytes, ToBytes};
+    use crate::fields::{FromBytes, ToBytes};
     use std::ffi::CStr;
 
     #[test]

--- a/falco_event/src/types/string/cstr_array.rs
+++ b/falco_event/src/types/string/cstr_array.rs
@@ -33,6 +33,9 @@ impl<'a> FromBytes<'a> for Vec<&'a CStr> {
     }
 }
 
+/// Falco-style array-of-CStr formatter
+///
+/// Formats the array as `;`-separated strings (see [`CStrFormatter`]).
 pub struct CStrArrayFormatter<'a, T: AsRef<CStr>>(pub &'a Vec<T>);
 
 impl<T: AsRef<CStr>> Debug for CStrArrayFormatter<'_, T> {

--- a/falco_event/src/types/string/cstr_array.rs
+++ b/falco_event/src/types/string/cstr_array.rs
@@ -1,4 +1,5 @@
-use crate::fields::{FromBytes, FromBytesError, ToBytes};
+use crate::fields::ToBytes;
+use crate::fields::{FromBytes, FromBytesError};
 use crate::types::CStrFormatter;
 use std::ffi::CStr;
 use std::fmt::{Debug, Formatter, Write as _};

--- a/falco_event/src/types/string/cstr_pair_array.rs
+++ b/falco_event/src/types/string/cstr_pair_array.rs
@@ -41,6 +41,10 @@ impl<'a> FromBytes<'a> for Vec<(&'a CStr, &'a CStr)> {
     }
 }
 
+/// Falco-style array-of-CStr-pair formatter
+///
+/// Formats the array as `;`-separated `key=value` pair, where each key and value is formatted
+/// as a string (see [`CStrFormatter`]).
 pub struct CStrPairArrayFormatter<'a, T: AsRef<CStr>>(pub &'a Vec<(T, T)>);
 
 impl<T: AsRef<CStr>> Debug for CStrPairArrayFormatter<'_, T> {

--- a/falco_event/src/types/string/cstr_pair_array.rs
+++ b/falco_event/src/types/string/cstr_pair_array.rs
@@ -1,4 +1,5 @@
-use crate::event_derive::{CStrFormatter, FromBytes, FromBytesError, FromBytesResult, ToBytes};
+use crate::fields::{FromBytes, FromBytesError, ToBytes};
+use crate::types::string::cstr::CStrFormatter;
 use std::ffi::CStr;
 use std::fmt::{Debug, Formatter, Write as _};
 use std::io::Write;
@@ -25,7 +26,7 @@ impl<'a> ToBytes for Vec<(&'a CStr, &'a CStr)> {
 }
 
 impl<'a> FromBytes<'a> for Vec<(&'a CStr, &'a CStr)> {
-    fn from_bytes(buf: &mut &'a [u8]) -> FromBytesResult<Self> {
+    fn from_bytes(buf: &mut &'a [u8]) -> Result<Self, FromBytesError> {
         let flat_data: Vec<&'a CStr> = FromBytes::from_bytes(buf)?;
         let mut chunks = flat_data.chunks_exact(2);
         let mut data = Vec::new();
@@ -62,7 +63,7 @@ impl<T: AsRef<CStr>> Debug for CStrPairArrayFormatter<'_, T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::event_derive::{FromBytes, ToBytes};
+    use crate::fields::{FromBytes, ToBytes};
     use std::ffi::CStr;
 
     #[test]

--- a/falco_event/src/types/string/cstr_pair_array.rs
+++ b/falco_event/src/types/string/cstr_pair_array.rs
@@ -63,7 +63,8 @@ impl<T: AsRef<CStr>> Debug for CStrPairArrayFormatter<'_, T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::fields::{FromBytes, ToBytes};
+    use crate::fields::FromBytes;
+    use crate::fields::ToBytes;
     use std::ffi::CStr;
 
     #[test]

--- a/falco_event/src/types/time/duration.rs
+++ b/falco_event/src/types/time/duration.rs
@@ -1,10 +1,10 @@
-use crate::event_derive::{FromBytes, FromBytesResult, ToBytes};
+use crate::fields::{FromBytes, FromBytesError, ToBytes};
 use byteorder::{NativeEndian, ReadBytesExt};
 use std::io::Write;
 use std::time::Duration;
 
 impl FromBytes<'_> for Duration {
-    fn from_bytes(buf: &mut &[u8]) -> FromBytesResult<Self>
+    fn from_bytes(buf: &mut &[u8]) -> Result<Self, FromBytesError>
     where
         Self: Sized,
     {

--- a/falco_event/src/types/time/system_time.rs
+++ b/falco_event/src/types/time/system_time.rs
@@ -1,5 +1,4 @@
-use crate::event_derive::ToBytes;
-use crate::fields::{FromBytes, FromBytesError};
+use crate::fields::{FromBytes, FromBytesError, ToBytes};
 use chrono::Local;
 use std::fmt::{Debug, Formatter};
 use std::io::Write;

--- a/falco_event/src/types/time/system_time.rs
+++ b/falco_event/src/types/time/system_time.rs
@@ -1,11 +1,11 @@
-use crate::event_derive::{FromBytes, FromBytesResult, ToBytes};
+use crate::fields::{FromBytes, FromBytesError, ToBytes};
 use chrono::Local;
 use std::fmt::{Debug, Formatter};
 use std::io::Write;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 impl FromBytes<'_> for SystemTime {
-    fn from_bytes(buf: &mut &[u8]) -> FromBytesResult<Self>
+    fn from_bytes(buf: &mut &[u8]) -> Result<Self, FromBytesError>
     where
         Self: Sized,
     {

--- a/falco_event/src/types/time/system_time.rs
+++ b/falco_event/src/types/time/system_time.rs
@@ -1,4 +1,5 @@
-use crate::fields::{FromBytes, FromBytesError, ToBytes};
+use crate::event_derive::ToBytes;
+use crate::fields::{FromBytes, FromBytesError};
 use chrono::Local;
 use std::fmt::{Debug, Formatter};
 use std::io::Write;

--- a/falco_event_derive/src/binary_payload.rs
+++ b/falco_event_derive/src/binary_payload.rs
@@ -27,7 +27,7 @@ pub fn derive_to_bytes(input: TokenStream) -> TokenStream {
 
             return TokenStream::from(quote!(
             impl #impl_generics #crate_path::PayloadToBytes for #name #ty_generics #where_clause {
-                fn write<W: std::io::Write>(&self, metadata: &#crate_path::EventMetadata, mut writer: W) -> std::io::Result<()> {
+                fn write<W: std::io::Write>(&self, metadata: &crate::events::EventMetadata, mut writer: W) -> std::io::Result<()> {
                     use #crate_path::*;
                     use crate::events::EventPayload;
 

--- a/falco_event_derive/src/binary_payload.rs
+++ b/falco_event_derive/src/binary_payload.rs
@@ -104,6 +104,7 @@ pub fn derive_from_bytes(input: TokenStream) -> TokenStream {
                 fn read(mut params: impl Iterator<Item=#crate_path::FromBytesResult<&'a [u8]>>) -> Result<Self, crate::events::PayloadFromBytesError> {
                     use #crate_path::*;
                     use crate::events::PayloadFromBytesError;
+                    use crate::fields::FromBytes;
                     #(#field_reads)*
 
                     Ok(#name {

--- a/falco_event_derive/src/binary_payload.rs
+++ b/falco_event_derive/src/binary_payload.rs
@@ -101,8 +101,9 @@ pub fn derive_from_bytes(input: TokenStream) -> TokenStream {
 
             return TokenStream::from(quote!(
             impl<'a> #crate_path::PayloadFromBytes<'a> for #name #ty_generics #where_clause {
-                fn read(mut params: impl Iterator<Item=#crate_path::FromBytesResult<&'a [u8]>>) -> #crate_path::PayloadFromBytesResult<Self> {
+                fn read(mut params: impl Iterator<Item=#crate_path::FromBytesResult<&'a [u8]>>) -> Result<Self, crate::events::PayloadFromBytesError> {
                     use #crate_path::*;
+                    use crate::events::PayloadFromBytesError;
                     #(#field_reads)*
 
                     Ok(#name {

--- a/falco_event_derive/src/binary_payload.rs
+++ b/falco_event_derive/src/binary_payload.rs
@@ -30,6 +30,7 @@ pub fn derive_to_bytes(input: TokenStream) -> TokenStream {
                 fn write<W: std::io::Write>(&self, metadata: &crate::events::EventMetadata, mut writer: W) -> std::io::Result<()> {
                     use #crate_path::*;
                     use crate::events::EventPayload;
+                    use crate::fields::ToBytes;
 
                     const NUM_FIELDS: usize = #num_fields;
                     let length_size = if Self::LARGE { 4 } else { 2 };

--- a/falco_event_derive/src/binary_payload.rs
+++ b/falco_event_derive/src/binary_payload.rs
@@ -74,7 +74,6 @@ pub fn derive_from_bytes(input: TokenStream) -> TokenStream {
     // Parse it as a proc macro
     let input = parse_macro_input!(input as DeriveInput);
 
-    let crate_path: syn::Path = syn::parse(quote!(crate::event_derive).into()).unwrap();
     let (_, ty_generics, where_clause) = input.generics.split_for_impl();
 
     if let syn::Data::Struct(ref data) = input.data {
@@ -101,9 +100,8 @@ pub fn derive_from_bytes(input: TokenStream) -> TokenStream {
             let name = input.ident;
 
             return TokenStream::from(quote!(
-            impl<'a> #crate_path::PayloadFromBytes<'a> for #name #ty_generics #where_clause {
+            impl<'a> crate::events::PayloadFromBytes<'a> for #name #ty_generics #where_clause {
                 fn read(mut params: impl Iterator<Item=crate::fields::FromBytesResult<&'a [u8]>>) -> Result<Self, crate::events::PayloadFromBytesError> {
-                    use #crate_path::*;
                     use crate::events::PayloadFromBytesError;
                     use crate::fields::FromBytes;
                     #(#field_reads)*

--- a/falco_event_derive/src/binary_payload.rs
+++ b/falco_event_derive/src/binary_payload.rs
@@ -26,7 +26,7 @@ pub fn derive_to_bytes(input: TokenStream) -> TokenStream {
             let num_fields = fields.named.len();
 
             return TokenStream::from(quote!(
-            impl #impl_generics #crate_path::PayloadToBytes for #name #ty_generics #where_clause {
+            impl #impl_generics crate::events::PayloadToBytes for #name #ty_generics #where_clause {
                 fn write<W: std::io::Write>(&self, metadata: &crate::events::EventMetadata, mut writer: W) -> std::io::Result<()> {
                     use #crate_path::*;
                     use crate::events::EventPayload;

--- a/falco_event_derive/src/binary_payload.rs
+++ b/falco_event_derive/src/binary_payload.rs
@@ -101,7 +101,7 @@ pub fn derive_from_bytes(input: TokenStream) -> TokenStream {
 
             return TokenStream::from(quote!(
             impl<'a> #crate_path::PayloadFromBytes<'a> for #name #ty_generics #where_clause {
-                fn read(mut params: impl Iterator<Item=#crate_path::FromBytesResult<&'a [u8]>>) -> Result<Self, crate::events::PayloadFromBytesError> {
+                fn read(mut params: impl Iterator<Item=crate::fields::FromBytesResult<&'a [u8]>>) -> Result<Self, crate::events::PayloadFromBytesError> {
                     use #crate_path::*;
                     use crate::events::PayloadFromBytesError;
                     use crate::fields::FromBytes;

--- a/falco_event_derive/src/binary_payload.rs
+++ b/falco_event_derive/src/binary_payload.rs
@@ -7,7 +7,6 @@ pub fn derive_to_bytes(input: TokenStream) -> TokenStream {
     // Parse it as a proc macro
     let input = parse_macro_input!(input as DeriveInput);
 
-    let crate_path: syn::Path = syn::parse(quote!(crate::event_derive).into()).unwrap();
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
     if let syn::Data::Struct(ref data) = input.data {
@@ -28,7 +27,8 @@ pub fn derive_to_bytes(input: TokenStream) -> TokenStream {
             return TokenStream::from(quote!(
             impl #impl_generics crate::events::PayloadToBytes for #name #ty_generics #where_clause {
                 fn write<W: std::io::Write>(&self, metadata: &crate::events::EventMetadata, mut writer: W) -> std::io::Result<()> {
-                    use #crate_path::*;
+                    use byteorder::NativeEndian;
+                    use byteorder::WriteBytesExt;
                     use crate::events::EventPayload;
                     use crate::fields::ToBytes;
 

--- a/falco_event_derive/src/binary_payload.rs
+++ b/falco_event_derive/src/binary_payload.rs
@@ -29,6 +29,8 @@ pub fn derive_to_bytes(input: TokenStream) -> TokenStream {
             impl #impl_generics #crate_path::PayloadToBytes for #name #ty_generics #where_clause {
                 fn write<W: std::io::Write>(&self, metadata: &#crate_path::EventMetadata, mut writer: W) -> std::io::Result<()> {
                     use #crate_path::*;
+                    use crate::events::EventPayload;
+
                     const NUM_FIELDS: usize = #num_fields;
                     let length_size = if Self::LARGE { 4 } else { 2 };
                     let lengths: [usize; NUM_FIELDS] =

--- a/falco_event_derive/src/dynamic_params.rs
+++ b/falco_event_derive/src/dynamic_params.rs
@@ -204,7 +204,7 @@ impl DynamicParam {
 
             impl<'a> crate::fields::FromBytes<'a> for #name #lifetime {
                 fn from_bytes(buf: &mut &'a [u8]) -> crate::fields::FromBytesResult<Self> {
-                    use crate::event_derive::ReadBytesExt;
+                    use byteorder::ReadBytesExt;
                     let variant = buf.read_u8()?;
                     match variant as u32 {
                         #(#variant_reads,)*

--- a/falco_event_derive/src/dynamic_params.rs
+++ b/falco_event_derive/src/dynamic_params.rs
@@ -203,7 +203,7 @@ impl DynamicParam {
             }
 
             impl<'a> crate::fields::FromBytes<'a> for #name #lifetime {
-                fn from_bytes(buf: &mut &'a [u8]) -> crate::event_derive::FromBytesResult<Self> {
+                fn from_bytes(buf: &mut &'a [u8]) -> crate::fields::FromBytesResult<Self> {
                     use crate::event_derive::ReadBytesExt;
                     let variant = buf.read_u8()?;
                     match variant as u32 {

--- a/falco_event_derive/src/dynamic_params.rs
+++ b/falco_event_derive/src/dynamic_params.rs
@@ -208,7 +208,7 @@ impl DynamicParam {
                     let variant = buf.read_u8()?;
                     match variant as u32 {
                         #(#variant_reads,)*
-                        _ => Err(crate::event_derive::FromBytesError::InvalidDynDiscriminant),
+                        _ => Err(crate::fields::FromBytesError::InvalidDynDiscriminant),
                     }
                 }
             }

--- a/falco_event_derive/src/dynamic_params.rs
+++ b/falco_event_derive/src/dynamic_params.rs
@@ -192,7 +192,7 @@ impl DynamicParam {
                     }
                 }
                 fn write<W: std::io::Write>(&self, mut writer: W) -> std::io::Result<()> {
-                    use crate::event_derive::WriteBytesExt;
+                    use byteorder::WriteBytesExt;
 
                     match self {
                         #(#variant_write)*

--- a/falco_event_derive/src/dynamic_params.rs
+++ b/falco_event_derive/src/dynamic_params.rs
@@ -88,7 +88,7 @@ impl DynamicParamVariant {
 
         quote!(crate::ffi:: #disc => {
             Ok(Self:: #disc(
-                <#ty as crate::event_derive::FromBytes>::from_bytes(buf)?
+                <#ty as crate::fields::FromBytes>::from_bytes(buf)?
             ))
         })
     }
@@ -202,7 +202,7 @@ impl DynamicParam {
                 fn default_repr() -> impl crate::event_derive::ToBytes { crate::event_derive::NoDefault }
             }
 
-            impl<'a> crate::event_derive::FromBytes<'a> for #name #lifetime {
+            impl<'a> crate::fields::FromBytes<'a> for #name #lifetime {
                 fn from_bytes(buf: &mut &'a [u8]) -> crate::event_derive::FromBytesResult<Self> {
                     use crate::event_derive::ReadBytesExt;
                     let variant = buf.read_u8()?;

--- a/falco_event_derive/src/dynamic_params.rs
+++ b/falco_event_derive/src/dynamic_params.rs
@@ -199,7 +199,7 @@ impl DynamicParam {
                     }
                 }
 
-                fn default_repr() -> impl crate::event_derive::ToBytes { crate::event_derive::NoDefault }
+                fn default_repr() -> impl crate::event_derive::ToBytes { crate::fields::NoDefault }
             }
 
             impl<'a> crate::fields::FromBytes<'a> for #name #lifetime {

--- a/falco_event_derive/src/dynamic_params.rs
+++ b/falco_event_derive/src/dynamic_params.rs
@@ -104,7 +104,7 @@ impl DynamicParamVariant {
 
         quote!(Self:: #disc(val) => {
             writer.write_u8(crate::ffi::#disc as u8)?;
-            crate::event_derive::ToBytes::write(val, writer)
+            crate::fields::ToBytes::write(val, writer)
         })
     }
 
@@ -184,9 +184,9 @@ impl DynamicParam {
                 #(#variant_definitions,)*
             }
 
-            impl #lifetime crate::event_derive::ToBytes for #name #lifetime {
+            impl #lifetime crate::fields::ToBytes for #name #lifetime {
                 fn binary_size(&self) -> usize {
-                    use crate::event_derive::ToBytes;
+                    use crate::fields::ToBytes;
                     match self {
                         #(#variant_binary_size,)*
                     }
@@ -199,7 +199,7 @@ impl DynamicParam {
                     }
                 }
 
-                fn default_repr() -> impl crate::event_derive::ToBytes { crate::fields::NoDefault }
+                fn default_repr() -> impl crate::fields::ToBytes { crate::fields::NoDefault }
             }
 
             impl<'a> crate::fields::FromBytes<'a> for #name #lifetime {

--- a/falco_event_derive/src/event_flags.rs
+++ b/falco_event_derive/src/event_flags.rs
@@ -193,7 +193,7 @@ fn render_enum(
             }
         }
 
-        impl crate::event_derive::FromBytes<'_> for #name {
+        impl crate::fields::FromBytes<'_> for #name {
             fn from_bytes(buf: &mut &[u8]) -> crate::event_derive::FromBytesResult<Self>
             where
                 Self: Sized,
@@ -260,7 +260,7 @@ fn render_bitflags(
             }
         }
 
-        impl crate::event_derive::FromBytes<'_> for #name {
+        impl crate::fields::FromBytes<'_> for #name {
             fn from_bytes(buf: &mut &[u8]) -> crate::event_derive::FromBytesResult<Self>
             where
                 Self: Sized,

--- a/falco_event_derive/src/event_flags.rs
+++ b/falco_event_derive/src/event_flags.rs
@@ -178,7 +178,7 @@ fn render_enum(
             }
         }
 
-        impl crate::event_derive::ToBytes for #name {
+        impl crate::fields::ToBytes for #name {
             fn binary_size(&self) -> usize {
                 std::mem::size_of::<#repr_type>()
             }
@@ -188,7 +188,7 @@ fn render_enum(
                 repr.write(writer)
             }
 
-            fn default_repr() -> impl crate::event_derive::ToBytes {
+            fn default_repr() -> impl crate::fields::ToBytes {
                 0 as #repr_type
             }
         }
@@ -246,7 +246,7 @@ fn render_bitflags(
             }
         }
 
-        impl crate::event_derive::ToBytes for #name {
+        impl crate::fields::ToBytes for #name {
             fn binary_size(&self) -> usize {
                 std::mem::size_of::<#repr_type>()
             }
@@ -255,7 +255,7 @@ fn render_bitflags(
                 (self.bits() as #repr_type).write(writer)
             }
 
-            fn default_repr() -> impl crate::event_derive::ToBytes {
+            fn default_repr() -> impl crate::fields::ToBytes {
                 0 as #repr_type
             }
         }

--- a/falco_event_derive/src/event_flags.rs
+++ b/falco_event_derive/src/event_flags.rs
@@ -194,7 +194,7 @@ fn render_enum(
         }
 
         impl crate::fields::FromBytes<'_> for #name {
-            fn from_bytes(buf: &mut &[u8]) -> crate::event_derive::FromBytesResult<Self>
+            fn from_bytes(buf: &mut &[u8]) -> crate::fields::FromBytesResult<Self>
             where
                 Self: Sized,
             {
@@ -261,7 +261,7 @@ fn render_bitflags(
         }
 
         impl crate::fields::FromBytes<'_> for #name {
-            fn from_bytes(buf: &mut &[u8]) -> crate::event_derive::FromBytesResult<Self>
+            fn from_bytes(buf: &mut &[u8]) -> crate::fields::FromBytesResult<Self>
             where
                 Self: Sized,
             {

--- a/falco_event_derive/src/event_info.rs
+++ b/falco_event_derive/src/event_info.rs
@@ -485,10 +485,10 @@ fn raw_event_load_any(events: &Events) -> proc_macro2::TokenStream {
 
     quote!(
         impl crate::event_derive::RawEvent<'_> {
-            pub fn load_any(&self) -> crate::event_derive::PayloadFromBytesResult<crate::event_derive::Event<AnyEvent>> {
+            pub fn load_any(&self) -> Result<crate::events::Event<AnyEvent>, crate::events::PayloadFromBytesError> {
                 let any: AnyEvent = match self.event_type as u32 {
                     #(#matches,)*
-                    other => return Err(crate::event_derive::PayloadFromBytesError::UnsupportedEventType(other)),
+                    other => return Err(crate::events::PayloadFromBytesError::UnsupportedEventType(other)),
                 };
 
                 Ok(crate::event_derive::Event {

--- a/falco_event_derive/src/event_info.rs
+++ b/falco_event_derive/src/event_info.rs
@@ -491,7 +491,7 @@ fn raw_event_load_any(events: &Events) -> proc_macro2::TokenStream {
                     other => return Err(crate::events::PayloadFromBytesError::UnsupportedEventType(other)),
                 };
 
-                Ok(crate::event_derive::Event {
+                Ok(crate::events::Event {
                     metadata: self.metadata.clone(),
                     params: any,
                 })

--- a/falco_event_derive/src/event_info.rs
+++ b/falco_event_derive/src/event_info.rs
@@ -262,7 +262,7 @@ impl EventInfo {
                 #(#dirfd_methods)*
             }
 
-            impl #lifetime crate::event_derive::EventPayload for #event_code #lifetime {
+            impl #lifetime crate::events::EventPayload for #event_code #lifetime {
                 const ID: EventType = EventType:: #event_type;
                 const LARGE: bool = #is_large;
                 const NAME: &'static str = #name;
@@ -272,7 +272,7 @@ impl EventInfo {
                 fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                     use std::fmt::Write;
 
-                    match <Self as crate::event_derive::EventPayload>::direction() {
+                    match <Self as crate::events::EventPayload>::direction() {
                         crate::event_derive::EventDirection::Entry => f.write_str("> ")?,
                         crate::event_derive::EventDirection::Exit => f.write_str("< ")?,
                     }
@@ -341,7 +341,7 @@ impl EventInfo {
         );
         quote!(crate::ffi:: #raw_ident => {
             let params = unsafe {
-                if <#event_code as crate::event_derive::EventPayload>::LARGE {
+                if <#event_code as crate::events::EventPayload>::LARGE {
                     <#event_code as crate::event_derive::PayloadFromBytes>::read(self.params::<u32>()?)?
                 } else {
                     <#event_code as crate::event_derive::PayloadFromBytes>::read(self.params::<u16>()?)?

--- a/falco_event_derive/src/event_info.rs
+++ b/falco_event_derive/src/event_info.rs
@@ -227,7 +227,7 @@ impl EventInfo {
 
             let display_wrapper =
                 display_wrapper_for(&field.field_type, quote!(self.#ident.as_ref()));
-            let display_val = quote!(crate::event_derive::OptionFormatter(#display_wrapper));
+            let display_val = quote!(crate::format::OptionFormatter(#display_wrapper));
 
             let format_val = formatter_for(
                 &field.field_type,

--- a/falco_event_derive/src/event_info.rs
+++ b/falco_event_derive/src/event_info.rs
@@ -484,7 +484,7 @@ fn raw_event_load_any(events: &Events) -> proc_macro2::TokenStream {
     let matches = events.enum_matches();
 
     quote!(
-        impl crate::event_derive::RawEvent<'_> {
+        impl crate::events::RawEvent<'_> {
             pub fn load_any(&self) -> Result<crate::events::Event<AnyEvent>, crate::events::PayloadFromBytesError> {
                 let any: AnyEvent = match self.event_type as u32 {
                     #(#matches,)*

--- a/falco_event_derive/src/event_info.rs
+++ b/falco_event_derive/src/event_info.rs
@@ -447,7 +447,7 @@ fn event_info_variant(events: &Events) -> proc_macro2::TokenStream {
             #(#variants,)*
         }
 
-        impl #lifetime crate::event_derive::PayloadToBytes for AnyEvent #lifetime {
+        impl #lifetime crate::events::PayloadToBytes for AnyEvent #lifetime {
             fn write<W: std::io::Write>(&self, metadata: &crate::events::EventMetadata, writer: W) -> std::io::Result<()> {
                 match self {
                     #(#variants_to_bytes)*

--- a/falco_event_derive/src/event_info.rs
+++ b/falco_event_derive/src/event_info.rs
@@ -273,8 +273,8 @@ impl EventInfo {
                     use std::fmt::Write;
 
                     match <Self as crate::events::EventPayload>::direction() {
-                        crate::event_derive::EventDirection::Entry => f.write_str("> ")?,
-                        crate::event_derive::EventDirection::Exit => f.write_str("< ")?,
+                        crate::events::EventDirection::Entry => f.write_str("> ")?,
+                        crate::events::EventDirection::Exit => f.write_str("< ")?,
                     }
                     f.write_str(#name)?;
                     #(#field_fmts)*

--- a/falco_event_derive/src/event_info.rs
+++ b/falco_event_derive/src/event_info.rs
@@ -448,7 +448,7 @@ fn event_info_variant(events: &Events) -> proc_macro2::TokenStream {
         }
 
         impl #lifetime crate::event_derive::PayloadToBytes for AnyEvent #lifetime {
-            fn write<W: std::io::Write>(&self, metadata: &crate::event_derive::EventMetadata, writer: W) -> std::io::Result<()> {
+            fn write<W: std::io::Write>(&self, metadata: &crate::events::EventMetadata, writer: W) -> std::io::Result<()> {
                 match self {
                     #(#variants_to_bytes)*
                 }

--- a/falco_event_derive/src/event_info.rs
+++ b/falco_event_derive/src/event_info.rs
@@ -342,9 +342,9 @@ impl EventInfo {
         quote!(crate::ffi:: #raw_ident => {
             let params = unsafe {
                 if <#event_code as crate::events::EventPayload>::LARGE {
-                    <#event_code as crate::event_derive::PayloadFromBytes>::read(self.params::<u32>()?)?
+                    <#event_code as crate::events::PayloadFromBytes>::read(self.params::<u32>()?)?
                 } else {
-                    <#event_code as crate::event_derive::PayloadFromBytes>::read(self.params::<u16>()?)?
+                    <#event_code as crate::events::PayloadFromBytes>::read(self.params::<u16>()?)?
                 }
             };
             AnyEvent::#event_type(params)

--- a/falco_event_derive/src/format.rs
+++ b/falco_event_derive/src/format.rs
@@ -10,7 +10,7 @@ pub fn display_wrapper_for(
         "PT_BYTEBUF" => quote!(#val_tt.map(|t| crate::format::ByteBufFormatter(t))),
         "PT_CHARBUF" => quote!(#val_tt.map(|t| crate::event_derive::CStrFormatter(t))),
         "PT_CHARBUFARRAY" => {
-            quote!(#val_tt.map(|t| crate::event_derive::CStrArrayFormatter(&t)))
+            quote!(#val_tt.map(|t| crate::format::CStrArrayFormatter(&t)))
         }
         "PT_CHARBUF_PAIR_ARRAY" => {
             quote!(#val_tt.map(|t| crate::event_derive::CStrPairArrayFormatter(&t)))

--- a/falco_event_derive/src/format.rs
+++ b/falco_event_derive/src/format.rs
@@ -6,7 +6,7 @@ pub fn display_wrapper_for(
     val_tt: proc_macro2::TokenStream,
 ) -> proc_macro2::TokenStream {
     match pt_type.to_string().as_str() {
-        "PT_ABSTIME" => quote!(#val_tt.map(|t| crate::event_derive::SystemTimeFormatter(*t))),
+        "PT_ABSTIME" => quote!(#val_tt.map(|t| crate::format::SystemTimeFormatter(*t))),
         "PT_BYTEBUF" => quote!(#val_tt.map(|t| crate::format::ByteBufFormatter(t))),
         "PT_CHARBUF" => quote!(#val_tt.map(|t| crate::format::CStrFormatter(t))),
         "PT_CHARBUFARRAY" => {

--- a/falco_event_derive/src/format.rs
+++ b/falco_event_derive/src/format.rs
@@ -13,7 +13,7 @@ pub fn display_wrapper_for(
             quote!(#val_tt.map(|t| crate::format::CStrArrayFormatter(&t)))
         }
         "PT_CHARBUF_PAIR_ARRAY" => {
-            quote!(#val_tt.map(|t| crate::event_derive::CStrPairArrayFormatter(&t)))
+            quote!(#val_tt.map(|t| crate::format::CStrPairArrayFormatter(&t)))
         }
         "PT_FSPATH" => quote!(#val_tt.map(|p| p.display())),
         _ => val_tt,

--- a/falco_event_derive/src/format.rs
+++ b/falco_event_derive/src/format.rs
@@ -8,7 +8,7 @@ pub fn display_wrapper_for(
     match pt_type.to_string().as_str() {
         "PT_ABSTIME" => quote!(#val_tt.map(|t| crate::event_derive::SystemTimeFormatter(*t))),
         "PT_BYTEBUF" => quote!(#val_tt.map(|t| crate::format::ByteBufFormatter(t))),
-        "PT_CHARBUF" => quote!(#val_tt.map(|t| crate::event_derive::CStrFormatter(t))),
+        "PT_CHARBUF" => quote!(#val_tt.map(|t| crate::format::CStrFormatter(t))),
         "PT_CHARBUFARRAY" => {
             quote!(#val_tt.map(|t| crate::format::CStrArrayFormatter(&t)))
         }

--- a/falco_event_derive/src/format.rs
+++ b/falco_event_derive/src/format.rs
@@ -7,7 +7,7 @@ pub fn display_wrapper_for(
 ) -> proc_macro2::TokenStream {
     match pt_type.to_string().as_str() {
         "PT_ABSTIME" => quote!(#val_tt.map(|t| crate::event_derive::SystemTimeFormatter(*t))),
-        "PT_BYTEBUF" => quote!(#val_tt.map(|t| crate::event_derive::ByteBufFormatter(t))),
+        "PT_BYTEBUF" => quote!(#val_tt.map(|t| crate::format::ByteBufFormatter(t))),
         "PT_CHARBUF" => quote!(#val_tt.map(|t| crate::event_derive::CStrFormatter(t))),
         "PT_CHARBUFARRAY" => {
             quote!(#val_tt.map(|t| crate::event_derive::CStrArrayFormatter(&t)))

--- a/falco_plugin_runner/src/plugin/extract.rs
+++ b/falco_plugin_runner/src/plugin/extract.rs
@@ -4,7 +4,7 @@ use crate::plugin::get_last_owner_error;
 use crate::tables::{TABLE_READER, TABLE_READER_EXT};
 use falco_event::fields::types::PT_IPNET;
 use falco_event::fields::FromBytes;
-use falco_event::SystemTimeFormatter;
+use falco_event::format::SystemTimeFormatter;
 use falco_plugin_api::{
     plugin_api__bindgen_ty_2, ss_plugin_extract_field, ss_plugin_extract_field__bindgen_ty_1,
     ss_plugin_extract_value_offsets, ss_plugin_field_extract_input, ss_plugin_owner_t,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area ci

/area event

> /area event_derive

> /area plugin

> /area plugin_api

> /area plugin_derive

> /area plugin_tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

The falco_event::event_derive module is (was) a collection of private reexports of items from falco_event, to be used by the derive macros. The major issue is that because the module is private, the derive macros can only be called from the falco_event crate itself. In an upcoming PR, we'll introduce and publish derive macros for building your own event types (e.g. an AnyEvent subset that only supports the events your plugin needs), so prepare some ground for this now.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

1. It's a no-op
2. I'm effectively submitting two series of PRs in parallel (support for custom event types/enums and performance/benchmarking work) and in an ideal world, these would be more independent but honestly I'm tired of shuffling the commits around and fixing the same trivial conflicts over and over (no, rerere and mergiraf don't make it all go away, even if they help)

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
NONE
```