### PR TITLE
update(event): assorted RawEvent fixes and improvements

### DIFF
--- a/falco_event/src/events/metadata.rs
+++ b/falco_event/src/events/metadata.rs
@@ -1,6 +1,8 @@
 use crate::format::OptionFormatter;
 use crate::types::SystemTimeFormatter;
+use byteorder::{NativeEndian, WriteBytesExt};
 use std::fmt::{Debug, Formatter};
+use std::io::Write;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 #[derive(Clone)]
@@ -16,6 +18,53 @@ impl EventMetadata {
         } else {
             Some(UNIX_EPOCH + Duration::from_nanos(self.ts))
         }
+    }
+
+    /// Write event header
+    ///
+    /// To form a valid event, after calling this method, the caller must write out the payload
+    /// at exactly `len - 26` bytes, containing `nparam` lengths (as the proper type)
+    /// and the parameter values themselves.
+    pub fn write_header<W: Write>(
+        &self,
+        len: u32,
+        event_type: u16,
+        nparams: u32,
+        mut writer: W,
+    ) -> std::io::Result<()> {
+        writer.write_u64::<NativeEndian>(self.ts)?;
+        writer.write_i64::<NativeEndian>(self.tid)?;
+
+        writer.write_u32::<NativeEndian>(len)?;
+        writer.write_u16::<NativeEndian>(event_type)?;
+        writer.write_u32::<NativeEndian>(nparams)?;
+
+        Ok(())
+    }
+
+    /// Write event header and parameter lengths
+    ///
+    /// To form a valid event, after calling this method, the caller must write out the payload
+    /// for each parameter, `lengths[i]` bytes in length.
+    pub fn write_header_with_lengths<W: Write, L: Into<u32> + Copy, const N: usize>(
+        &self,
+        event_type: u16,
+        lengths: [L; N],
+        mut writer: W,
+    ) -> std::io::Result<()> {
+        let len = 26 + // header
+            (size_of::<L>() * lengths.len()) as u32 +
+            lengths.iter().copied().map(Into::into).sum::<u32>();
+
+        let nparams = lengths.len();
+
+        self.write_header(len, event_type, nparams as u32, &mut writer)?;
+        let lengths: &[u8] = unsafe {
+            std::slice::from_raw_parts(lengths.as_ptr().cast(), lengths.len() * size_of::<L>())
+        };
+        writer.write_all(lengths)?;
+
+        Ok(())
     }
 }
 

--- a/falco_event/src/events/mod.rs
+++ b/falco_event/src/events/mod.rs
@@ -2,9 +2,9 @@ pub use event::Event;
 pub use metadata::EventMetadata;
 pub use payload::EventDirection;
 pub use payload::EventPayload;
-pub use payload::PayloadFromBytes;
 pub use payload::PayloadFromBytesError;
 pub use payload::PayloadToBytes;
+pub use raw_event::FromRawEvent;
 pub use raw_event::RawEvent;
 pub use to_bytes::EventToBytes;
 

--- a/falco_event/src/events/payload.rs
+++ b/falco_event/src/events/payload.rs
@@ -1,6 +1,6 @@
 use crate::events::types::EventType;
 use crate::events::EventMetadata;
-use crate::fields::{FromBytesError, FromBytesResult};
+use crate::fields::FromBytesError;
 use std::io::Write;
 use thiserror::Error;
 
@@ -14,6 +14,8 @@ pub trait EventPayload {
     const ID: EventType;
     const LARGE: bool;
     const NAME: &'static str;
+
+    type LengthType;
 
     fn direction() -> EventDirection {
         match Self::ID as u32 % 2 {
@@ -43,14 +45,6 @@ pub enum PayloadFromBytesError {
     UnsupportedEventType(u32),
 }
 
-pub type PayloadFromBytesResult<T> = Result<T, PayloadFromBytesError>;
-
 pub trait PayloadToBytes {
     fn write<W: Write>(&self, metadata: &EventMetadata, writer: W) -> std::io::Result<()>;
-}
-
-pub trait PayloadFromBytes<'a>: Sized {
-    fn read(
-        params: impl Iterator<Item = FromBytesResult<&'a [u8]>>,
-    ) -> PayloadFromBytesResult<Self>;
 }

--- a/falco_event/src/events/payload.rs
+++ b/falco_event/src/events/payload.rs
@@ -12,7 +12,6 @@ pub enum EventDirection {
 
 pub trait EventPayload {
     const ID: EventType;
-    const LARGE: bool;
     const NAME: &'static str;
 
     type LengthType;

--- a/falco_event/src/events/raw_event.rs
+++ b/falco_event/src/events/raw_event.rs
@@ -17,7 +17,7 @@ pub struct RawEvent<'a> {
     pub payload: &'a [u8],
 }
 
-impl RawEvent<'_> {
+impl<'e> RawEvent<'e> {
     pub fn from(mut buf: &[u8]) -> std::io::Result<RawEvent> {
         let ts = buf.read_u64::<NativeEndian>()?;
         let tid = buf.read_i64::<NativeEndian>()?;
@@ -84,7 +84,10 @@ impl RawEvent<'_> {
     /// `T` must correspond to the type of the length field (u16 or u32, depending on event type)
     pub unsafe fn params<T>(
         &self,
-    ) -> Result<impl Iterator<Item = Result<&[u8], FromBytesError>>, PayloadFromBytesError> {
+    ) -> Result<
+        impl Iterator<Item = Result<&'e [u8], FromBytesError>> + use<'e, T>,
+        PayloadFromBytesError,
+    > {
         let ll = unsafe { self.lengths_length::<T>() };
 
         if self.payload.len() < ll {

--- a/falco_event/src/events/raw_event.rs
+++ b/falco_event/src/events/raw_event.rs
@@ -49,9 +49,7 @@ impl<'e> RawEvent<'e> {
         Self::from(buf)
     }
 
-    pub fn load<'a, T: PayloadFromBytes<'a> + EventPayload>(
-        &'a self,
-    ) -> PayloadFromBytesResult<Event<T>> {
+    pub fn load_params<T: PayloadFromBytes<'e> + EventPayload>(&self) -> PayloadFromBytesResult<T> {
         if self.event_type != T::ID as u16 {
             return Err(PayloadFromBytesError::TypeMismatch);
         }
@@ -62,6 +60,13 @@ impl<'e> RawEvent<'e> {
                 T::read(self.params::<u16>()?)
             }
         }?;
+        Ok(params)
+    }
+
+    pub fn load<'a, T: PayloadFromBytes<'a> + EventPayload>(
+        &'a self,
+    ) -> PayloadFromBytesResult<Event<T>> {
+        let params = self.load_params::<T>()?;
         Ok(Event {
             metadata: self.metadata.clone(),
             params,

--- a/falco_event/src/events/raw_event.rs
+++ b/falco_event/src/events/raw_event.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 
-use byteorder::{NativeEndian, ReadBytesExt, WriteBytesExt};
+use byteorder::{NativeEndian, ReadBytesExt};
 
 use crate::events::payload::PayloadFromBytesError;
 use crate::events::{Event, EventMetadata, EventToBytes};
@@ -153,13 +153,8 @@ impl<'e> RawEvent<'e> {
 
 impl EventToBytes for RawEvent<'_> {
     fn write<W: Write>(&self, mut writer: W) -> std::io::Result<()> {
-        writer.write_u64::<NativeEndian>(self.metadata.ts)?;
-        writer.write_i64::<NativeEndian>(self.metadata.tid)?;
-
-        writer.write_u32::<NativeEndian>(self.len)?;
-        writer.write_u16::<NativeEndian>(self.event_type)?;
-        writer.write_u32::<NativeEndian>(self.nparams)?;
-
+        self.metadata
+            .write_header(self.len, self.event_type, self.nparams, &mut writer)?;
         writer.write_all(self.payload)
     }
 }

--- a/falco_event/src/events/raw_event.rs
+++ b/falco_event/src/events/raw_event.rs
@@ -108,12 +108,10 @@ impl<'e> RawEvent<'e> {
         if self.event_type != T::ID as u16 {
             return Err(PayloadFromBytesError::TypeMismatch);
         }
-        let params = unsafe {
-            if T::LARGE {
-                T::read(self.params::<u32>()?)
-            } else {
-                T::read(self.params::<u16>()?)
-            }
+        let params = if T::LARGE {
+            T::read(self.params::<u32>()?)
+        } else {
+            T::read(self.params::<u16>()?)
         }?;
         Ok(params)
     }
@@ -128,10 +126,10 @@ impl<'e> RawEvent<'e> {
         })
     }
 
-    /// # Safety
+    /// Get an iterator over the event parameters
     ///
-    /// `T` must correspond to the type of the length field (u16 or u32, depending on event type)
-    pub unsafe fn params<T>(
+    /// `T` must correspond to the type of the length field (u16 or u32, depending on the event type)
+    pub fn params<T>(
         &self,
     ) -> Result<
         impl Iterator<Item = Result<&'e [u8], FromBytesError>> + use<'e, T>,

--- a/falco_event/src/fields/from_bytes.rs
+++ b/falco_event/src/fields/from_bytes.rs
@@ -36,9 +36,13 @@ pub enum FromBytesError {
     #[error("invalid PT_DYN discriminant")]
     InvalidDynDiscriminant,
 
-    /// Odd item count in pair array
+    /// Odd item count in a pair array
     #[error("odd item count in pair array")]
     OddPairItemCount,
+
+    /// Unconsumed data remaining in field buffer
+    #[error("trailing field data")]
+    LeftoverData,
 }
 
 /// The result of a deserialization

--- a/falco_event/src/fields/mod.rs
+++ b/falco_event/src/fields/mod.rs
@@ -1,6 +1,5 @@
 pub use from_bytes::FromBytes;
 pub use from_bytes::FromBytesError;
-pub use from_bytes::FromBytesResult;
 pub use to_bytes::NoDefault;
 pub use to_bytes::ToBytes;
 

--- a/falco_event/src/types/fd_list.rs
+++ b/falco_event/src/types/fd_list.rs
@@ -1,9 +1,8 @@
+use crate::fields::event_flags::PT_FLAGS16_file_flags;
+use crate::fields::{FromBytes, FromBytesError, ToBytes};
+use byteorder::{NativeEndian, ReadBytesExt, WriteBytesExt};
 use std::fmt::{Debug, Formatter};
 use std::io::Write;
-
-use crate::fields::event_flags::PT_FLAGS16_file_flags;
-use crate::fields::{FromBytes, FromBytesResult, ToBytes};
-use byteorder::{NativeEndian, ReadBytesExt, WriteBytesExt};
 
 /// A list of file descriptors with flags
 #[derive(Clone, Eq, PartialEq)]
@@ -49,7 +48,7 @@ impl ToBytes for FdList {
 }
 
 impl FromBytes<'_> for FdList {
-    fn from_bytes(buf: &mut &[u8]) -> FromBytesResult<Self> {
+    fn from_bytes(buf: &mut &[u8]) -> Result<Self, FromBytesError> {
         let mut fds = Vec::new();
         let len = buf.read_u16::<NativeEndian>()?;
         for _ in 0..len as usize {

--- a/falco_event/src/types/primitive/integers.rs
+++ b/falco_event/src/types/primitive/integers.rs
@@ -1,10 +1,10 @@
-use crate::fields::{FromBytes, FromBytesResult, ToBytes};
+use crate::fields::{FromBytes, FromBytesError, ToBytes};
 use byteorder::{ReadBytesExt, WriteBytesExt};
 
 macro_rules! impl_int_type {
     ($ty:ty) => {
         impl FromBytes<'_> for $ty {
-            fn from_bytes(buf: &mut &[u8]) -> FromBytesResult<Self>
+            fn from_bytes(buf: &mut &[u8]) -> Result<Self, FromBytesError>
             where
                 Self: Sized,
             {
@@ -32,7 +32,7 @@ macro_rules! impl_int_type {
 macro_rules! impl_uint_type {
     ($ty:ty) => {
         impl FromBytes<'_> for $ty {
-            fn from_bytes(buf: &mut &[u8]) -> FromBytesResult<Self>
+            fn from_bytes(buf: &mut &[u8]) -> Result<Self, FromBytesError>
             where
                 Self: Sized,
             {

--- a/falco_event/src/types/primitive/newtypes.rs
+++ b/falco_event/src/types/primitive/newtypes.rs
@@ -1,4 +1,4 @@
-use crate::fields::{FromBytes, FromBytesResult, ToBytes};
+use crate::fields::{FromBytes, FromBytesError, ToBytes};
 use std::fmt::{Debug, Formatter, LowerHex};
 
 macro_rules! default_debug {
@@ -18,7 +18,7 @@ macro_rules! newtype {
         pub struct $name(pub $repr);
 
         impl FromBytes<'_> for $name {
-            fn from_bytes(buf: &mut &[u8]) -> FromBytesResult<Self>
+            fn from_bytes(buf: &mut &[u8]) -> Result<Self, FromBytesError>
             where
                 Self: Sized,
             {

--- a/falco_event_derive/src/binary_payload.rs
+++ b/falco_event_derive/src/binary_payload.rs
@@ -87,7 +87,9 @@ pub fn derive_from_bytes(input: TokenStream) -> TokenStream {
                     let #name = FromBytes::from_maybe_bytes(maybe_next_field.as_mut())
                         .map_err(|e| PayloadFromBytesError::NamedField(#name_str, e))?;
                     if let Some(buf) = maybe_next_field {
-                        debug_assert!(buf.is_empty());
+                        if !buf.is_empty() {
+                            return Err(PayloadFromBytesError::NamedField(#name_str, FromBytesError::LeftoverData));
+                        }
                     }
                 )
             });
@@ -104,6 +106,7 @@ pub fn derive_from_bytes(input: TokenStream) -> TokenStream {
                 fn read(mut params: impl Iterator<Item=crate::fields::FromBytesResult<&'a [u8]>>) -> Result<Self, crate::events::PayloadFromBytesError> {
                     use crate::events::PayloadFromBytesError;
                     use crate::fields::FromBytes;
+                    use crate::fields::FromBytesError;
                     #(#field_reads)*
 
                     Ok(#name {

--- a/falco_event_derive/src/dynamic_params.rs
+++ b/falco_event_derive/src/dynamic_params.rs
@@ -203,10 +203,9 @@ impl DynamicParam {
             }
 
             impl<'a> crate::fields::FromBytes<'a> for #name #lifetime {
-                fn from_bytes(buf: &mut &'a [u8]) -> crate::fields::FromBytesResult<Self> {
-                    use byteorder::ReadBytesExt;
-                    let variant = buf.read_u8()?;
-                    match variant as u32 {
+                fn from_bytes(buf: &mut &'a [u8]) -> Result<Self, crate::fields::FromBytesError> {
+                    let variant = buf.split_off_first().ok_or_else(|| crate::fields::FromBytesError::InvalidLength)?;
+                    match *variant as u32 {
                         #(#variant_reads,)*
                         _ => Err(crate::fields::FromBytesError::InvalidDynDiscriminant),
                     }

--- a/falco_event_derive/src/event_flags.rs
+++ b/falco_event_derive/src/event_flags.rs
@@ -194,7 +194,8 @@ fn render_enum(
         }
 
         impl crate::fields::FromBytes<'_> for #name {
-            fn from_bytes(buf: &mut &[u8]) -> crate::fields::FromBytesResult<Self>
+            #[inline(always)]
+            fn from_bytes(buf: &mut &[u8]) -> Result<Self, crate::fields::FromBytesError>
             where
                 Self: Sized,
             {
@@ -261,7 +262,8 @@ fn render_bitflags(
         }
 
         impl crate::fields::FromBytes<'_> for #name {
-            fn from_bytes(buf: &mut &[u8]) -> crate::fields::FromBytesResult<Self>
+            #[inline(always)]
+            fn from_bytes(buf: &mut &[u8]) -> Result<Self, crate::fields::FromBytesError>
             where
                 Self: Sized,
             {

--- a/falco_event_derive/src/event_info.rs
+++ b/falco_event_derive/src/event_info.rs
@@ -268,7 +268,6 @@ impl EventInfo {
 
             impl #lifetime crate::events::EventPayload for #event_code #lifetime {
                 const ID: EventType = EventType:: #event_type;
-                const LARGE: bool = #is_large;
                 const NAME: &'static str = #name;
 
                 type LengthType = #length_type;

--- a/falco_event_derive/src/event_info.rs
+++ b/falco_event_derive/src/event_info.rs
@@ -340,13 +340,7 @@ impl EventInfo {
             self.event_code.span(),
         );
         quote!(crate::ffi:: #raw_ident => {
-            let params = unsafe {
-                if <#event_code as crate::events::EventPayload>::LARGE {
-                    <#event_code as crate::events::PayloadFromBytes>::read(self.params::<u32>()?)?
-                } else {
-                    <#event_code as crate::events::PayloadFromBytes>::read(self.params::<u16>()?)?
-                }
-            };
+            let params = self.load_params::<#event_code>()?;
             AnyEvent::#event_type(params)
         })
     }

--- a/falco_event_derive/src/event_info.rs
+++ b/falco_event_derive/src/event_info.rs
@@ -484,8 +484,8 @@ fn raw_event_load_any(events: &Events) -> proc_macro2::TokenStream {
     let matches = events.enum_matches();
 
     quote!(
-        impl crate::events::RawEvent<'_> {
-            pub fn load_any(&self) -> Result<crate::events::Event<AnyEvent>, crate::events::PayloadFromBytesError> {
+        impl<'e> crate::events::RawEvent<'e> {
+            pub fn load_any(&self) -> Result<crate::events::Event<AnyEvent<'e>>, crate::events::PayloadFromBytesError> {
                 let any: AnyEvent = match self.event_type as u32 {
                     #(#matches,)*
                     other => return Err(crate::events::PayloadFromBytesError::UnsupportedEventType(other)),

--- a/falco_event_serde/src/de/payload.rs
+++ b/falco_event_serde/src/de/payload.rs
@@ -18,7 +18,11 @@ falco_event::derive_deftly_for_events! {
             ];
 
             let event_type_id = <falco_event::events::types::$ttype as EventPayload>::ID as u16;
-            let large_payload = <falco_event::events::types::$ttype as EventPayload>::LARGE;
+            let large_payload = match size_of::<<falco_event::events::types::$ttype as EventPayload>::LengthType>() {
+                2 => false,
+                4 => true,
+                _ => panic!("Invalid length type for event payload"),
+            };
 
             RawEvent {
                 ts: metadata.ts,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area ci

/area event

> /area event_derive

> /area plugin

> /area plugin_api

> /area plugin_derive

> /area plugin_tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This is a collection of RawEvent fixes and cleanups that I want to get in before we get to the real juicy stuff.

The TL;DR is:
* return proper lifetimes from .params() and .load_any() (these need to be tied to the lifetime of the actual RawEvent, not the reference to one that we pass in)
* add two helpers useful when dealing with a linear buffer with multiple events inside:
  * RawEvent::trim (don't consume the whole buffer as the first event with trailing junk, but rather return the extra tail instead)
  * RawEvent::scan (yield individual events from a large buffer one by one, until the buffer is consumed)
* make trailing field data return an error; previously, we either crashed (in debug builds) or ignored it completely (in release builds)
* make RawEvent::params no longer unsafe (it should have never been unsafe in the first place)
* move all of the parsing responsibility into the payload type, rather than having RawEvent::load care about the size of lengths for a particular event type (which doesn't make sense for AnyEvent, so we need a dedicated method for it... for now)
* some spring cleaning, preparing for upcoming changes

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Best viewed commit by commit, but there isn't really anything fascinating in there :)

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
NONE
```