### PR TITLE
chore(build): fix clippy warnings after rust 1.88 upgrade

### DIFF
--- a/falco_event/src/types/net/sockaddr.rs
+++ b/falco_event/src/types/net/sockaddr.rs
@@ -85,7 +85,7 @@ impl Debug for SockAddr<'_> {
             SockAddr::Unix(u) => write!(f, "unix://{}", u.display()),
             SockAddr::V4(v4) => write!(f, "{}:{}", v4.0, v4.1 .0),
             SockAddr::V6(v6) => write!(f, "[{}]:{}", v6.0, v6.1 .0),
-            SockAddr::Other(af, raw) => write!(f, "<af={}>{:02x?}", af, raw),
+            SockAddr::Other(af, raw) => write!(f, "<af={af}>{raw:02x?}"),
         }
     }
 }

--- a/falco_event/src/types/net/socktuple.rs
+++ b/falco_event/src/types/net/socktuple.rs
@@ -211,7 +211,7 @@ mod tests {
             path,
         } = socktuple
         else {
-            panic!("not a unix sock tuple: {:?}", socktuple)
+            panic!("not a unix sock tuple: {socktuple:?}")
         };
 
         assert_eq!(source_addr, 0);

--- a/falco_event/src/types/primitive/newtypes.rs
+++ b/falco_event/src/types/primitive/newtypes.rs
@@ -261,7 +261,7 @@ impl Debug for SigSet {
                 } else {
                     write!(fmt, ",")?;
                 }
-                write!(fmt, "{:?}", sig)?;
+                write!(fmt, "{sig:?}")?;
             }
             write!(fmt, ")")?;
         }

--- a/falco_event_derive/src/event_flags.rs
+++ b/falco_event_derive/src/event_flags.rs
@@ -317,7 +317,7 @@ fn render_flags_type(
     items: &Punctuated<FlagItem, Token![,]>,
     skips: &Skips,
 ) -> proc_macro2::TokenStream {
-    let final_name = Ident::new(&format!("{}_{}", underlying_type, name), name.span());
+    let final_name = Ident::new(&format!("{underlying_type}_{name}"), name.span());
 
     let items = items.iter().filter_map(|it| {
         let NumberOr::Token(ref name) = it.name else {
@@ -339,7 +339,7 @@ fn render_flags_type(
         "PT_ENUMFLAGS32" => render_enum(&final_name, quote!(u32), items, skips),
         "PT_ENUMFLAGS16" => render_enum(&final_name, quote!(u16), items, skips),
         "PT_ENUMFLAGS8" => render_enum(&final_name, quote!(u8), items, skips),
-        _ => panic!("unsupported type {}", underlying_type),
+        _ => panic!("unsupported type {underlying_type}"),
     }
 }
 
@@ -355,8 +355,7 @@ fn render_derive_deftly(
         {
             match underlying_type.to_string().as_str() {
                 "PT_ENUMFLAGS32" | "PT_ENUMFLAGS16" | "PT_ENUMFLAGS8" => {
-                    let final_name =
-                        Ident::new(&format!("{}_{}", underlying_type, name), name.span());
+                    let final_name = Ident::new(&format!("{underlying_type}_{name}"), name.span());
                     Some(quote!(
                         $crate::derive_deftly::derive_deftly_adhoc! {
                             $crate::#final_name: $($body)*
@@ -379,8 +378,7 @@ fn render_derive_deftly(
         {
             match underlying_type.to_string().as_str() {
                 "PT_FLAGS32" | "PT_FLAGS16" | "PT_FLAGS8" | "PT_MODE" => {
-                    let final_name =
-                        Ident::new(&format!("{}_{}", underlying_type, name), name.span());
+                    let final_name = Ident::new(&format!("{underlying_type}_{name}"), name.span());
                     Some(quote!(
                         $crate::derive_deftly::derive_deftly_adhoc! {
                             $crate::#final_name: $($body)*

--- a/falco_event_derive/src/event_info.rs
+++ b/falco_event_derive/src/event_info.rs
@@ -68,7 +68,7 @@ impl EventArg {
         let mut name = Ident::new(&self.name.value(), self.name.span());
         if syn::parse::<Ident>(quote!(#name).into()).is_err() {
             // #name is a keyword
-            name = Ident::new(&format!("{}_", name), name.span());
+            name = Ident::new(&format!("{name}_"), name.span());
         }
 
         name

--- a/falco_plugin/src/plugin/base/logger.rs
+++ b/falco_plugin/src/plugin/base/logger.rs
@@ -49,7 +49,7 @@ impl Log for FalcoPluginLogger {
             let loc = record
                 .file()
                 .zip(record.line())
-                .map(|(f, l)| Cow::Owned(format!("{}:{}", f, l)))
+                .map(|(f, l)| Cow::Owned(format!("{f}:{l}")))
                 .unwrap_or_else(|| Cow::Borrowed(record.target()));
             format!("{}[{}] {}", loc, record.level(), record.args())
         };

--- a/falco_plugin/src/plugin/base/mod.rs
+++ b/falco_plugin/src/plugin/base/mod.rs
@@ -53,8 +53,8 @@ impl<P: Plugin> PluginWrapper<P> {
 
         plugin
             .error_buf
-            .write_into(|buf| write!(buf, "{}", err))
-            .unwrap_or_else(|err| panic!("Failed to write error message (was: {})", err));
+            .write_into(|buf| write!(buf, "{err}"))
+            .unwrap_or_else(|err| panic!("Failed to write error message (was: {err})"));
 
         plugin
     }

--- a/falco_plugin/src/plugin/base/wrappers.rs
+++ b/falco_plugin/src/plugin/base/wrappers.rs
@@ -41,7 +41,7 @@ pub extern "C-unwind" fn plugin_get_required_api_version<
     version
         .entry((MAJOR, MINOR, PATCH))
         .or_insert_with(|| {
-            let version = format!("{}.{}.{}", MAJOR, MINOR, PATCH);
+            let version = format!("{MAJOR}.{MINOR}.{PATCH}");
             CString::new(version).unwrap()
         })
         .as_ptr()
@@ -112,7 +112,7 @@ pub unsafe extern "C-unwind" fn plugin_init<P: Plugin>(
         }
         Err(e) => {
             let error_str = format!("{:#}", &e);
-            log::error!("Failed to initialize plugin: {}", error_str);
+            log::error!("Failed to initialize plugin: {error_str}");
             let plugin = Box::new(PluginWrapper::<P>::new_error(error_str));
             unsafe {
                 *rc = e.status_code();

--- a/falco_plugin/src/plugin/error/ffi_result.rs
+++ b/falco_plugin/src/plugin/error/ffi_result.rs
@@ -27,12 +27,12 @@ impl FfiResult for anyhow::Error {
         #[cfg(debug_assertions)]
         match self.status_code() {
             falco_plugin_api::ss_plugin_rc_SS_PLUGIN_EOF => {
-                log::debug!("EOF from plugin: {}", self)
+                log::debug!("EOF from plugin: {self}")
             }
             falco_plugin_api::ss_plugin_rc_SS_PLUGIN_TIMEOUT => {
-                log::trace!("Plugin timeout: {}", self)
+                log::trace!("Plugin timeout: {self}")
             }
-            _ => log::warn!("Plugin error: {:#}", self),
+            _ => log::warn!("Plugin error: {self:#}"),
         }
 
         if let Ok(mut msg) = CString::new(msg.into_bytes()) {

--- a/falco_plugin/src/plugin/error/last_error.rs
+++ b/falco_plugin/src/plugin/error/last_error.rs
@@ -38,7 +38,7 @@ impl LastError {
                 Err(e) => e.to_string(),
             };
 
-            log::warn!("Got error from API: {}", msg);
+            log::warn!("Got error from API: {msg}");
             Some(msg)
         }
     }

--- a/falco_plugin_derive/src/lib.rs
+++ b/falco_plugin_derive/src/lib.rs
@@ -132,7 +132,7 @@ pub fn derive_table_metadata(input: TokenStream) -> TokenStream {
         .filter(|a| a.path().is_ident("accessors_mod"))
         .filter_map(|a| a.parse_args::<Ident>().ok())
         .next()
-        .unwrap_or_else(|| Ident::new(&format!("__falco_plugin_private_{}", name), name.span()));
+        .unwrap_or_else(|| Ident::new(&format!("__falco_plugin_private_{name}"), name.span()));
 
     let mut field_traits = Vec::new();
     let mut field_trait_impls = vec![impl_table_metadata];
@@ -144,10 +144,10 @@ pub fn derive_table_metadata(input: TokenStream) -> TokenStream {
             };
             let ty = &f.ty;
 
-            let getter_name = Ident::new(&format!("get_{}", field_name), field_name.span());
+            let getter_name = Ident::new(&format!("get_{field_name}"), field_name.span());
             let table_getter_name =
-                Ident::new(&format!("get_{}_by_key", field_name), field_name.span());
-            let setter_name = Ident::new(&format!("set_{}", field_name), field_name.span());
+                Ident::new(&format!("get_{field_name}_by_key"), field_name.span());
+            let setter_name = Ident::new(&format!("set_{field_name}"), field_name.span());
 
             field_traits.push(quote!(
                 ::falco_plugin::impl_import_table_accessor_traits!(

--- a/falco_plugin_runner/src/plugin/async_event.rs
+++ b/falco_plugin_runner/src/plugin/async_event.rs
@@ -111,7 +111,7 @@ unsafe extern "C-unwind" fn async_handler(
     let raw_event = match RawEvent::from(event) {
         Ok(event) => event,
         Err(e) => {
-            write_err_msg(err, &format!("Failed to parse event: {}", e));
+            write_err_msg(err, &format!("Failed to parse event: {e}"));
             return ss_plugin_rc_SS_PLUGIN_FAILURE;
         }
     };
@@ -119,7 +119,7 @@ unsafe extern "C-unwind" fn async_handler(
     let async_event = match raw_event.load::<PPME_ASYNCEVENT_E>() {
         Ok(event) => event,
         Err(e) => {
-            write_err_msg(err, &format!("Failed to parse async event: {}", e));
+            write_err_msg(err, &format!("Failed to parse async event: {e}"));
             return ss_plugin_rc_SS_PLUGIN_FAILURE;
         }
     };
@@ -137,7 +137,7 @@ unsafe extern "C-unwind" fn async_handler(
         Err(e) => {
             write_err_msg(
                 err,
-                &format!("Failed to decode async event name as UTF-8: {}", e),
+                &format!("Failed to decode async event name as UTF-8: {e}"),
             );
             return ss_plugin_rc_SS_PLUGIN_FAILURE;
         }

--- a/falco_plugin_runner/src/plugin/extract.rs
+++ b/falco_plugin_runner/src/plugin/extract.rs
@@ -77,7 +77,7 @@ impl Display for ExtractedField {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             ExtractedField::None => write!(f, "<NA>"),
-            ExtractedField::U64(value) => write!(f, "{}", value),
+            ExtractedField::U64(value) => write!(f, "{value}"),
             ExtractedField::String(cstr) => write!(f, "{}", cstr.to_string_lossy()),
             ExtractedField::Vec(vector) => {
                 let mut first = true;
@@ -88,7 +88,7 @@ impl Display for ExtractedField {
                     } else {
                         write!(f, ",")?;
                     }
-                    write!(f, "{}", val)?;
+                    write!(f, "{val}")?;
                 }
                 write!(f, ")")?;
                 Ok(())
@@ -101,14 +101,14 @@ impl Display for ExtractedField {
                 }
             }
             ExtractedField::RelTime(t) => {
-                write!(f, "{:?}", t)
+                write!(f, "{t:?}")
             }
             ExtractedField::AbsTime(t) => {
                 let dt = chrono::DateTime::<Local>::from(*t);
                 f.write_str(&dt.to_rfc3339_opts(chrono::SecondsFormat::AutoSi, false))
             }
             ExtractedField::IpAddr(addr) => {
-                write!(f, "{:?}", addr)
+                write!(f, "{addr:?}")
             }
             ExtractedField::IpNet(_) => {
                 write!(f, "<IPNET>")

--- a/falco_plugin_runner/src/plugin/mod.rs
+++ b/falco_plugin_runner/src/plugin/mod.rs
@@ -46,7 +46,7 @@ impl Display for ScapStatus {
             ScapStatus::Timeout => f.write_str("Timeout"),
             ScapStatus::Eof => f.write_str("Eof"),
             ScapStatus::NotSupported => f.write_str("NotSupported"),
-            ScapStatus::Other(rc) => write!(f, "Other({})", rc),
+            ScapStatus::Other(rc) => write!(f, "Other({rc})"),
         }
     }
 }

--- a/falco_plugin_tests/benches/plugin_custom_tables.rs
+++ b/falco_plugin_tests/benches/plugin_custom_tables.rs
@@ -200,7 +200,7 @@ fn bench_plugin_custom_table_extract_only_impl<D: TestDriver, M: Measurement>(
                 for _ in 0..NUM_EVENTS {
                     match criterion::black_box(driver.extract_field(c"thread.val_direct", &event)) {
                         Ok(_) => (),
-                        Err(e) => panic!("Unexpected error: {}", e),
+                        Err(e) => panic!("Unexpected error: {e}"),
                     }
                 }
             });
@@ -224,7 +224,7 @@ fn bench_plugin_custom_table_extract_only_impl<D: TestDriver, M: Measurement>(
                 for _ in 0..NUM_EVENTS {
                     match criterion::black_box(driver.extract_field(c"thread.val_api", &event)) {
                         Ok(_) => (),
-                        Err(e) => panic!("Unexpected error: {}", e),
+                        Err(e) => panic!("Unexpected error: {e}"),
                     }
                 }
             });
@@ -250,7 +250,7 @@ fn bench_plugin_custom_table_extract_only_impl<D: TestDriver, M: Measurement>(
                 for _ in 0..NUM_EVENTS {
                     match criterion::black_box(driver.extract_field(c"thread.val2_api", &event)) {
                         Ok(_) => (),
-                        Err(e) => panic!("Unexpected error: {}", e),
+                        Err(e) => panic!("Unexpected error: {e}"),
                     }
                 }
             });
@@ -292,7 +292,7 @@ fn bench_plugin_custom_table_insert_and_extract_impl<D: TestDriver, M: Measureme
                         criterion::black_box(driver.extract_field(c"thread.val_direct", &event));
                     match as_string {
                         Ok(_) => (),
-                        Err(e) => panic!("Unexpected error: {}", e),
+                        Err(e) => panic!("Unexpected error: {e}"),
                     }
                 }
             });
@@ -318,7 +318,7 @@ fn bench_plugin_custom_table_insert_and_extract_impl<D: TestDriver, M: Measureme
                         criterion::black_box(driver.extract_field(c"thread.val_api", &event));
                     match as_string {
                         Ok(_) => (),
-                        Err(e) => panic!("Unexpected error: {}", e),
+                        Err(e) => panic!("Unexpected error: {e}"),
                     }
                 }
             });
@@ -346,7 +346,7 @@ fn bench_plugin_custom_table_insert_and_extract_impl<D: TestDriver, M: Measureme
                         criterion::black_box(driver.extract_field(c"thread.val2_api", &event));
                     match as_string {
                         Ok(_) => (),
-                        Err(e) => panic!("Unexpected error: {}", e),
+                        Err(e) => panic!("Unexpected error: {e}"),
                     }
                 }
             });

--- a/falco_plugin_tests/benches/plugin_extract_static.rs
+++ b/falco_plugin_tests/benches/plugin_extract_static.rs
@@ -62,7 +62,7 @@ fn plugin_extract_static_impl<D: TestDriver, M: Measurement>(g: &mut BenchmarkGr
             for _ in 0..NUM_EVENTS {
                 match black_box(driver.extract_field(c"static.field", &event)) {
                     Ok(_) => (),
-                    Err(e) => panic!("Unexpected error: {}", e),
+                    Err(e) => panic!("Unexpected error: {e}"),
                 }
             }
         });

--- a/falco_plugin_tests/benches/plugin_source_batch.rs
+++ b/falco_plugin_tests/benches/plugin_source_batch.rs
@@ -27,7 +27,7 @@ fn bench_plugin_source_batch_impl<D: TestDriver, M: Measurement>(g: &mut Benchma
                     for _ in 0..NUM_EVENTS {
                         match black_box(driver.next_event()) {
                             Ok(_) => (),
-                            Err(e) => panic!("Unexpected error: {}", e),
+                            Err(e) => panic!("Unexpected error: {e}"),
                         }
                     }
                 });

--- a/falco_plugin_tests/benches/plugin_source_parse_noop.rs
+++ b/falco_plugin_tests/benches/plugin_source_parse_noop.rs
@@ -56,7 +56,7 @@ fn bench_plugin_source_parse_noop_impl<D: TestDriver, M: Measurement>(g: &mut Be
             for _ in 0..NUM_EVENTS {
                 match black_box(driver.next_event()) {
                     Ok(_) => (),
-                    Err(e) => panic!("Unexpected error: {}", e),
+                    Err(e) => panic!("Unexpected error: {e}"),
                 }
             }
         });

--- a/falco_plugin_tests/benches/plugin_threadinfo.rs
+++ b/falco_plugin_tests/benches/plugin_threadinfo.rs
@@ -129,7 +129,7 @@ fn bench_plugin_threadinfo_tid<D: TestDriver, M: Measurement>(g: &mut BenchmarkG
                 for _ in 0..NUM_EVENTS {
                     match criterion::black_box(driver.extract_field(c"thread.pid", &event)) {
                         Ok(_) => (),
-                        Err(e) => panic!("Unexpected error: {}", e),
+                        Err(e) => panic!("Unexpected error: {e}"),
                     }
                 }
             });
@@ -161,7 +161,7 @@ fn bench_plugin_threadinfo_missing_custom_field<D: TestDriver, M: Measurement>(
                     let as_string = driver.extract_field(c"thread.val", &event);
                     match as_string {
                         Ok(_) => (),
-                        Err(e) => panic!("Unexpected error: {}", e),
+                        Err(e) => panic!("Unexpected error: {e}"),
                     }
                 }
             });
@@ -190,7 +190,7 @@ fn bench_plugin_threadinfo_only_set_custom_field<D: TestDriver, M: Measurement>(
                 for _ in 0..NUM_EVENTS {
                     match criterion::black_box(driver.next_event()) {
                         Ok(_) => (),
-                        Err(e) => panic!("Unexpected error: {}", e),
+                        Err(e) => panic!("Unexpected error: {e}"),
                     }
                 }
             });
@@ -222,7 +222,7 @@ fn bench_plugin_threadinfo_custom_field<D: TestDriver, M: Measurement>(g: &mut B
                 for _ in 0..NUM_EVENTS {
                     match criterion::black_box(driver.extract_field(c"thread.val", &event)) {
                         Ok(_) => (),
-                        Err(e) => panic!("Unexpected error: {}", e),
+                        Err(e) => panic!("Unexpected error: {e}"),
                     }
                 }
             });

--- a/falco_plugin_tests/src/bin/dump_raw_events.rs
+++ b/falco_plugin_tests/src/bin/dump_raw_events.rs
@@ -63,7 +63,7 @@ fn main() {
         match driver.next_event() {
             Ok(_) => continue,
             Err(ScapStatus::Eof) => break,
-            Err(e) => panic!("{:?}", e),
+            Err(e) => panic!("{e:?}"),
         }
     }
 }

--- a/falco_plugin_tests/tests/async_tables.rs
+++ b/falco_plugin_tests/tests/async_tables.rs
@@ -155,7 +155,7 @@ impl ParsePlugin for DummyPlugin {
         self.imported_table
             .iter_entries_mut(&parse_input.reader, |e| {
                 let num = e.get_num(&parse_input.reader).unwrap();
-                log::info!("num = {}", num);
+                log::info!("num = {num}");
                 assert_eq!(num, counter);
                 counter += 1;
                 Continue(())

--- a/falco_plugin_tests/tests/capture_listen_resched.rs
+++ b/falco_plugin_tests/tests/capture_listen_resched.rs
@@ -112,7 +112,7 @@ mod tests {
                 Ok(_) => continue,
                 Err(ScapStatus::Timeout) => continue,
                 Err(ScapStatus::Eof) => break,
-                Err(e) => panic!("Got {:?}", e),
+                Err(e) => panic!("Got {e:?}"),
             }
         }
     }

--- a/falco_plugin_tests/tests/capture_listen_run_forever.rs
+++ b/falco_plugin_tests/tests/capture_listen_run_forever.rs
@@ -124,7 +124,7 @@ mod tests {
                 Ok(_) => continue,
                 Err(ScapStatus::Timeout) => continue,
                 Err(ScapStatus::Eof) => break,
-                Err(e) => panic!("Got {:?}", e),
+                Err(e) => panic!("Got {e:?}"),
             }
         }
     }

--- a/falco_plugin_tests/tests/extract.rs
+++ b/falco_plugin_tests/tests/extract.rs
@@ -53,7 +53,7 @@ impl SourcePluginInstance for DummyPluginInstance {
         if let Some(mut num_events) = self.0.take() {
             while num_events > 0 {
                 num_events -= 1;
-                let event = format!("{} events remaining", num_events);
+                let event = format!("{num_events} events remaining");
                 let event = Self::plugin_event(event.as_bytes());
                 batch.add(event)?;
             }

--- a/falco_plugin_tests/tests/extract_range.rs
+++ b/falco_plugin_tests/tests/extract_range.rs
@@ -54,7 +54,7 @@ impl SourcePluginInstance for DummyPluginInstance {
         if let Some(mut num_events) = self.0.take() {
             while num_events > 0 {
                 num_events -= 1;
-                let event = format!("{} events remaining", num_events);
+                let event = format!("{num_events} events remaining");
                 let event = Self::plugin_event(event.as_bytes());
                 batch.add(event)?;
             }

--- a/falco_plugin_tests/tests/extract_types.rs
+++ b/falco_plugin_tests/tests/extract_types.rs
@@ -46,7 +46,7 @@ impl SourcePluginInstance for DummyPluginInstance {
         if let Some(mut num_events) = self.0.take() {
             while num_events > 0 {
                 num_events -= 1;
-                let event = format!("{} events remaining", num_events);
+                let event = format!("{num_events} events remaining");
                 let event = Self::plugin_event(event.as_bytes());
                 batch.add(event)?;
             }

--- a/falco_plugin_tests/tests/parse.rs
+++ b/falco_plugin_tests/tests/parse.rs
@@ -69,7 +69,7 @@ impl SourcePluginInstance for DummyPluginInstance {
         if let Some(mut num_events) = self.0.take() {
             while num_events > 0 {
                 num_events -= 1;
-                let event = format!("{} events remaining", num_events);
+                let event = format!("{num_events} events remaining");
                 let event = Self::plugin_event(event.as_bytes());
                 batch.add(event)?;
             }

--- a/falco_plugin_tests/tests/parse_runtime.rs
+++ b/falco_plugin_tests/tests/parse_runtime.rs
@@ -68,7 +68,7 @@ impl SourcePluginInstance for DummyPluginInstance {
         if let Some(mut num_events) = self.0.take() {
             while num_events > 0 {
                 num_events -= 1;
-                let event = format!("{} events remaining", num_events);
+                let event = format!("{num_events} events remaining");
                 let event = Self::plugin_event(event.as_bytes());
                 batch.add(event)?;
             }

--- a/falco_plugin_tests/tests/parse_table_api.rs
+++ b/falco_plugin_tests/tests/parse_table_api.rs
@@ -88,7 +88,7 @@ impl SourcePluginInstance for DummyPluginInstance {
         if let Some(mut num_events) = self.0.take() {
             while num_events > 0 {
                 num_events -= 1;
-                let event = format!("{} events remaining", num_events);
+                let event = format!("{num_events} events remaining");
                 let event = Self::plugin_event(event.as_bytes());
                 batch.add(event)?;
             }
@@ -209,7 +209,7 @@ impl ParsePlugin for DummyParsePlugin {
 
         let is_even = (remaining % 2 == 0).into();
         let mut string_rep = CString::default();
-        string_rep.write_into(|w| write!(w, "{} events remaining", remaining))?;
+        string_rep.write_into(|w| write!(w, "{remaining} events remaining"))?;
 
         entry.set_is_even(&parse_input.writer, &is_even)?;
         entry.set_as_string(&parse_input.writer, string_rep.as_c_str())?;

--- a/falco_plugin_tests/tests/parse_table_nested.rs
+++ b/falco_plugin_tests/tests/parse_table_nested.rs
@@ -80,7 +80,7 @@ impl SourcePluginInstance for DummyPluginInstance {
         if let Some(mut num_events) = self.0.take() {
             while num_events > 0 {
                 num_events -= 1;
-                let event = format!("{} events remaining", num_events);
+                let event = format!("{num_events} events remaining");
                 let event = Self::plugin_event(event.as_bytes());
                 batch.add(event)?;
             }
@@ -222,7 +222,7 @@ impl ParsePlugin for DummyParsePlugin {
 
         let is_even = (remaining % 2 == 0).into();
         let mut string_rep = CString::default();
-        string_rep.write_into(|w| write!(w, "{} events remaining", remaining))?;
+        string_rep.write_into(|w| write!(w, "{remaining} events remaining"))?;
 
         entry.set_is_even(writer, &is_even)?;
         entry.set_as_string(writer, string_rep.as_c_str())?;

--- a/falco_plugin_tests/tests/scap.rs
+++ b/falco_plugin_tests/tests/scap.rs
@@ -91,7 +91,7 @@ mod tests {
                     counter += 1;
                 }
                 Err(ScapStatus::Eof) => break,
-                Err(e) => panic!("{:?}", e),
+                Err(e) => panic!("{e:?}"),
             }
         }
 
@@ -109,7 +109,7 @@ mod tests {
                     counter += 1;
                 }
                 Err(ScapStatus::Eof) => break,
-                Err(e) => panic!("{:?}", e),
+                Err(e) => panic!("{e:?}"),
             }
         }
 

--- a/falco_plugin_tests/tests/scap_import_table.rs
+++ b/falco_plugin_tests/tests/scap_import_table.rs
@@ -174,7 +174,7 @@ mod tests {
             match driver.next_event() {
                 Ok(_) => continue,
                 Err(ScapStatus::Eof) => break,
-                Err(e) => panic!("{:?}", e),
+                Err(e) => panic!("{e:?}"),
             }
         }
 

--- a/falco_plugin_tests/tests/source_batch.rs
+++ b/falco_plugin_tests/tests/source_batch.rs
@@ -49,7 +49,7 @@ impl SourcePluginInstance for DummyPluginInstance {
         if let Some(mut num_events) = self.0.take() {
             while num_events > 0 {
                 num_events -= 1;
-                let event = format!("{} events remaining", num_events);
+                let event = format!("{num_events} events remaining");
                 let event = Self::plugin_event(event.as_bytes());
                 batch.add(event)?;
             }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area ci

> /area event

> /area event_derive

> /area plugin

> /area plugin_api

> /area plugin_derive

> /area plugin_tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Clippy shipped with Rust 1.88 enables `#[warn(clippy::uninlined_format_args)]` by default. Not sure I like this choice but, well, I don't have a too strong opinion on this.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
NONE
```