### PR TITLE
cleanup: a round of warning fixes

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -58,6 +58,6 @@ jobs:
       - name: Check code formatting
         run: cargo fmt --check
       - name: Check clippy
-        run: cargo clippy --all-features
+        run: cargo clippy --all-features --all-targets
       - name: Render docs
         run: cargo doc --all-features --no-deps

--- a/falco_event/src/events/raw_event.rs
+++ b/falco_event/src/events/raw_event.rs
@@ -68,7 +68,7 @@ pub struct RawEvent<'a> {
 }
 
 impl<'e> RawEvent<'e> {
-    fn from_impl(mut buf: &[u8]) -> Option<RawEvent> {
+    fn from_impl(mut buf: &[u8]) -> Option<RawEvent<'_>> {
         let ts_buf = buf.split_off(..8)?;
         let ts = u64::from_ne_bytes(ts_buf.try_into().unwrap());
 
@@ -96,7 +96,7 @@ impl<'e> RawEvent<'e> {
     /// Parse a byte slice into a RawEvent
     ///
     /// This decodes the header while leaving the payload as a raw byte buffer.
-    pub fn from(buf: &[u8]) -> std::io::Result<RawEvent> {
+    pub fn from(buf: &[u8]) -> std::io::Result<RawEvent<'_>> {
         Self::from_impl(buf).ok_or(std::io::ErrorKind::InvalidData.into())
     }
 

--- a/falco_event/src/types/primitive/newtypes.rs
+++ b/falco_event/src/types/primitive/newtypes.rs
@@ -307,6 +307,7 @@ newtype!(
     /// Layer 4 protocol (tcp/udp)
     ///
     /// This looks unused
+    #[allow(unused)]
     L4Proto(u8)
 );
 default_debug!(L4Proto);

--- a/falco_event/src/types/string/cstr_pair_array.rs
+++ b/falco_event/src/types/string/cstr_pair_array.rs
@@ -31,7 +31,7 @@ impl<'a> FromBytes<'a> for CStrPairArray<'a> {
     #[inline]
     fn from_bytes(buf: &mut &'a [u8]) -> Result<Self, FromBytesError> {
         let nuls = buf.iter().filter(|b| **b == 0).count();
-        if nuls % 2 != 0 {
+        if !nuls.is_multiple_of(2) {
             return Err(FromBytesError::OddPairItemCount);
         }
         let array = CStrArray::from_bytes(buf)?;

--- a/falco_plugin/src/plugin/event.rs
+++ b/falco_plugin/src/plugin/event.rs
@@ -12,7 +12,7 @@ impl EventInput {
     ///
     /// This method parses the raw event data into a [`RawEvent`] instance,
     /// which can be later converted into a specific event type.
-    pub fn event(&self) -> std::io::Result<RawEvent> {
+    pub fn event(&self) -> std::io::Result<RawEvent<'_>> {
         unsafe { RawEvent::from_ptr(self.0.evt as *const _) }
     }
 

--- a/falco_plugin/src/plugin/extract/mod.rs
+++ b/falco_plugin/src/plugin/extract/mod.rs
@@ -35,11 +35,11 @@ pub enum ExtractFieldRequestArg<'a> {
 }
 
 pub trait ExtractField {
-    unsafe fn key_unchecked(&self) -> ExtractFieldRequestArg;
+    unsafe fn key_unchecked(&self) -> ExtractFieldRequestArg<'_>;
 }
 
 impl ExtractField for ss_plugin_extract_field {
-    unsafe fn key_unchecked(&self) -> ExtractFieldRequestArg {
+    unsafe fn key_unchecked(&self) -> ExtractFieldRequestArg<'_> {
         if self.arg_present == 0 {
             return ExtractFieldRequestArg::None;
         }

--- a/falco_plugin/src/plugin/source/event_batch.rs
+++ b/falco_plugin/src/plugin/source/event_batch.rs
@@ -12,7 +12,7 @@ pub struct EventBatch<'a> {
 }
 
 impl EventBatch<'_> {
-    pub(in crate::plugin::source) fn new(alloc: &bumpalo::Bump) -> EventBatch {
+    pub(in crate::plugin::source) fn new(alloc: &bumpalo::Bump) -> EventBatch<'_> {
         let pointers = bumpalo::collections::Vec::new_in(alloc);
         EventBatch { alloc, pointers }
     }

--- a/falco_plugin/src/plugin/source/mod.rs
+++ b/falco_plugin/src/plugin/source/mod.rs
@@ -183,7 +183,7 @@ pub trait SourcePluginInstance {
     ///
     /// It consists of a percentage (0.0-100.0) and an optional description containing more
     /// details about the progress (e.g. bytes read/bytes total).
-    fn get_progress(&mut self) -> ProgressInfo {
+    fn get_progress(&mut self) -> ProgressInfo<'_> {
         ProgressInfo {
             value: 0.0,
             detail: None,
@@ -198,7 +198,7 @@ pub trait SourcePluginInstance {
     ///
     /// This method makes it easy to generate such events: just pass it the event data and get
     /// the complete event, with all the metadata set to reasonable defaults.
-    fn plugin_event(data: &[u8]) -> Event<PluginEvent> {
+    fn plugin_event(data: &[u8]) -> Event<PluginEvent<'_>> {
         let event = PluginEvent {
             plugin_id: Some(Self::Plugin::PLUGIN_ID),
             event_data: Some(data),

--- a/falco_plugin/src/plugin/tables/table/raw.rs
+++ b/falco_plugin/src/plugin/tables/table/raw.rs
@@ -8,9 +8,8 @@ use crate::plugin::tables::vtable::reader::private::TableReaderImpl;
 use crate::plugin::tables::vtable::reader::TableReader;
 use crate::plugin::tables::vtable::writer::private::TableWriterImpl;
 use crate::plugin::tables::vtable::writer::TableWriter;
-use crate::plugin::tables::vtable::TableError;
 use crate::plugin::tables::vtable::TablesInput;
-use crate::strings::from_ptr::{try_str_from_ptr_with_lifetime, FromPtrError};
+use crate::strings::from_ptr::try_str_from_ptr_with_lifetime;
 use falco_plugin_api::{
     ss_plugin_bool, ss_plugin_rc_SS_PLUGIN_SUCCESS, ss_plugin_state_data, ss_plugin_state_type,
     ss_plugin_table_entry_t, ss_plugin_table_field_t, ss_plugin_table_fieldinfo,
@@ -19,15 +18,6 @@ use falco_plugin_api::{
 use num_traits::FromPrimitive;
 use std::ffi::CStr;
 use std::ops::ControlFlow;
-use thiserror::Error;
-
-#[derive(Debug, Error)]
-pub enum TableNameError {
-    #[error(transparent)]
-    TableError(#[from] TableError),
-    #[error(transparent)]
-    PtrError(#[from] FromPtrError),
-}
 
 struct TemporaryTableEntry<'a> {
     tables_input: &'a TablesInput<'a>,

--- a/falco_plugin/src/plugin/tables/vtable/reader.rs
+++ b/falco_plugin/src/plugin/tables/vtable/reader.rs
@@ -90,7 +90,7 @@ impl<'t> LazyTableReader<'t> {
     /// table accesses faster. If your plugin method does more than a few
     /// (say, 10) calls to methods that take a `TableReader`, it might be
     /// faster to get a `ValidatedTableReader`
-    pub fn validate(&self) -> Result<ValidatedTableReader, TableError> {
+    pub fn validate(&self) -> Result<ValidatedTableReader<'_>, TableError> {
         Ok(ValidatedTableReader {
             get_table_name: self
                 .reader_ext

--- a/falco_plugin/src/plugin/tables/vtable/writer.rs
+++ b/falco_plugin/src/plugin/tables/vtable/writer.rs
@@ -95,7 +95,7 @@ impl<'t> LazyTableWriter<'t> {
     /// table accesses faster. If your plugin method does more than a few
     /// (say, 10) calls to methods that take a `TableWriter`, it might be
     /// faster to get a `ValidatedTableWriter`
-    pub fn validate(&self) -> Result<ValidatedTableWriter, TableError> {
+    pub fn validate(&self) -> Result<ValidatedTableWriter<'_>, TableError> {
         Ok(ValidatedTableWriter {
             clear_table: self
                 .writer_ext

--- a/falco_plugin_tests/benches/binary_event_all.rs
+++ b/falco_plugin_tests/benches/binary_event_all.rs
@@ -4,7 +4,7 @@ use falco_plugin::event::events::{Event, EventToBytes, RawEvent};
 use std::hint::black_box;
 use std::path::PathBuf;
 
-fn load(events: &[u8]) -> Vec<Event<AnyEvent>> {
+fn load(events: &[u8]) -> Vec<Event<AnyEvent<'_>>> {
     RawEvent::scan(events)
         .map(|event| event.unwrap().load_any().unwrap())
         .collect()

--- a/falco_plugin_tests/src/ffi.rs
+++ b/falco_plugin_tests/src/ffi.rs
@@ -104,7 +104,7 @@ mod ffi {
             self: Pin<&mut SinspTestDriver>,
             field_name: *const c_char,
             event: &SinspEvent,
-        ) -> Result<SinspExtractedField>;
+        ) -> Result<SinspExtractedField<'_>>;
 
         fn get_metrics(
             self: Pin<&mut SinspTestDriver>,

--- a/falco_plugin_tests/tests/parse_table_api.rs
+++ b/falco_plugin_tests/tests/parse_table_api.rs
@@ -207,7 +207,7 @@ impl ParsePlugin for DummyParsePlugin {
             .get_entry(&parse_input.reader, &event_num)?;
         let remaining = entry.get_remaining(&parse_input.reader)?;
 
-        let is_even = (remaining % 2 == 0).into();
+        let is_even = remaining.is_multiple_of(2).into();
         let mut string_rep = CString::default();
         string_rep.write_into(|w| write!(w, "{remaining} events remaining"))?;
 

--- a/falco_plugin_tests/tests/parse_table_nested.rs
+++ b/falco_plugin_tests/tests/parse_table_nested.rs
@@ -220,7 +220,7 @@ impl ParsePlugin for DummyParsePlugin {
         let entry = self.remaining_table.get_entry(reader, &event_num)?;
         let remaining = entry.get_remaining(reader)?;
 
-        let is_even = (remaining % 2 == 0).into();
+        let is_even = remaining.is_multiple_of(2).into();
         let mut string_rep = CString::default();
         string_rep.write_into(|w| write!(w, "{remaining} events remaining"))?;
 

--- a/justfile
+++ b/justfile
@@ -49,3 +49,12 @@ pull version: (pull_api version) (pull_events version)
 regen: regen_api regen_events
 
 update version: (pull version) regen
+
+presubmit:
+    cargo clippy --all-targets --all-features -- -D warnings
+    cargo test --all-features
+    RUSTDOCFLAGS="--cfg docsrs" cargo doc --all-features --no-deps
+    cargo fmt --check || cargo fmt
+
+presubmit-pr base:
+    git rebase --exec "just presubmit" {{ base }}


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area ci

/area event

> /area event_derive

/area plugin

> /area plugin_api

> /area plugin_derive

> /area plugin_tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

I ran some experiments with the nightly compiler and I noticed a few new upcoming warnings (both from the compiler and clippy), so we might as well fix them now, rather than wait for 1.89 or 1.90 (they exist in the beta channel too, so they're coming to stable soon).

Also, I added two `justfile` tasks to make presubmit checks easier:
* `just presubmit` to run clippy, fmt, tests and render the docs for the current state of the repo
* `just presubmit-pr <upstream-branch>` (e.g. `just presubmit-pr origin/main`) to run the above for all commits between the upstream branch and current HEAD

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Silence before the storm ;) There's another minor one coming next and then a bomb drops in 3 parts (breaking source compatibility for all plugins, but I believe it's for a good reason)

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
NONE
```