### PR TITLE
cleanup(event)!: use std::net::SocketAddr* instead of custom types

### DIFF
--- a/falco_event/src/types/net/endpoint.rs
+++ b/falco_event/src/types/net/endpoint.rs
@@ -1,32 +1,33 @@
 use crate::fields::{FromBytes, FromBytesError, ToBytes};
 use std::io::Write;
-use std::net::{Ipv4Addr, Ipv6Addr};
-
-pub type SocketAddrV4 = (Ipv4Addr, u16);
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4};
 
 impl ToBytes for SocketAddrV4 {
     #[inline]
     fn binary_size(&self) -> usize {
-        self.0.binary_size() + self.1.binary_size()
+        self.ip().binary_size() + self.port().binary_size()
     }
 
     //noinspection DuplicatedCode
     #[inline]
     fn write<W: Write>(&self, mut writer: W) -> std::io::Result<()> {
-        self.0.write(&mut writer)?;
-        self.1.write(writer)
+        self.ip().write(&mut writer)?;
+        self.port().write(writer)
     }
 
     #[inline]
     fn default_repr() -> impl ToBytes {
-        (Ipv4Addr::from(0), 0)
+        SocketAddrV4::new(Ipv4Addr::from(0), 0)
     }
 }
 
 impl FromBytes<'_> for SocketAddrV4 {
     #[inline]
     fn from_bytes(buf: &mut &'_ [u8]) -> Result<Self, FromBytesError> {
-        Ok((FromBytes::from_bytes(buf)?, FromBytes::from_bytes(buf)?))
+        Ok(SocketAddrV4::new(
+            FromBytes::from_bytes(buf)?,
+            FromBytes::from_bytes(buf)?,
+        ))
     }
 }
 

--- a/falco_event/src/types/net/endpoint.rs
+++ b/falco_event/src/types/net/endpoint.rs
@@ -1,9 +1,8 @@
 use crate::fields::{FromBytes, FromBytesError, ToBytes};
-use crate::types::Port;
 use std::io::Write;
 use std::net::{Ipv4Addr, Ipv6Addr};
 
-pub type EndpointV4 = (Ipv4Addr, Port);
+pub type EndpointV4 = (Ipv4Addr, u16);
 
 impl ToBytes for EndpointV4 {
     #[inline]
@@ -20,7 +19,7 @@ impl ToBytes for EndpointV4 {
 
     #[inline]
     fn default_repr() -> impl ToBytes {
-        (Ipv4Addr::from(0), Port(0))
+        (Ipv4Addr::from(0), 0)
     }
 }
 
@@ -31,7 +30,7 @@ impl FromBytes<'_> for EndpointV4 {
     }
 }
 
-pub type EndpointV6 = (Ipv6Addr, Port);
+pub type EndpointV6 = (Ipv6Addr, u16);
 
 impl ToBytes for EndpointV6 {
     #[inline]
@@ -48,7 +47,7 @@ impl ToBytes for EndpointV6 {
 
     #[inline]
     fn default_repr() -> impl ToBytes {
-        (Ipv6Addr::from(0), Port(0))
+        (Ipv6Addr::from(0), 0)
     }
 }
 

--- a/falco_event/src/types/net/endpoint.rs
+++ b/falco_event/src/types/net/endpoint.rs
@@ -2,9 +2,9 @@ use crate::fields::{FromBytes, FromBytesError, ToBytes};
 use std::io::Write;
 use std::net::{Ipv4Addr, Ipv6Addr};
 
-pub type EndpointV4 = (Ipv4Addr, u16);
+pub type SocketAddrV4 = (Ipv4Addr, u16);
 
-impl ToBytes for EndpointV4 {
+impl ToBytes for SocketAddrV4 {
     #[inline]
     fn binary_size(&self) -> usize {
         self.0.binary_size() + self.1.binary_size()
@@ -23,7 +23,7 @@ impl ToBytes for EndpointV4 {
     }
 }
 
-impl FromBytes<'_> for EndpointV4 {
+impl FromBytes<'_> for SocketAddrV4 {
     #[inline]
     fn from_bytes(buf: &mut &'_ [u8]) -> Result<Self, FromBytesError> {
         Ok((FromBytes::from_bytes(buf)?, FromBytes::from_bytes(buf)?))

--- a/falco_event/src/types/net/endpoint.rs
+++ b/falco_event/src/types/net/endpoint.rs
@@ -30,9 +30,9 @@ impl FromBytes<'_> for SocketAddrV4 {
     }
 }
 
-pub type EndpointV6 = (Ipv6Addr, u16);
+pub type SocketAddrV6 = (Ipv6Addr, u16);
 
-impl ToBytes for EndpointV6 {
+impl ToBytes for SocketAddrV6 {
     #[inline]
     fn binary_size(&self) -> usize {
         self.0.binary_size() + self.1.binary_size()
@@ -51,7 +51,7 @@ impl ToBytes for EndpointV6 {
     }
 }
 
-impl FromBytes<'_> for EndpointV6 {
+impl FromBytes<'_> for SocketAddrV6 {
     #[inline]
     fn from_bytes(buf: &mut &'_ [u8]) -> Result<Self, FromBytesError> {
         Ok((FromBytes::from_bytes(buf)?, FromBytes::from_bytes(buf)?))

--- a/falco_event/src/types/net/mod.rs
+++ b/falco_event/src/types/net/mod.rs
@@ -8,7 +8,6 @@ mod ipv6net;
 mod sockaddr;
 mod socktuple;
 
-pub use endpoint::*;
 pub use ipnet::*;
 pub use ipv4net::*;
 pub use ipv6net::*;

--- a/falco_event/src/types/net/sockaddr.rs
+++ b/falco_event/src/types/net/sockaddr.rs
@@ -1,6 +1,6 @@
 use crate::ffi::{PPM_AF_INET, PPM_AF_INET6, PPM_AF_LOCAL, PPM_AF_UNSPEC};
 use crate::fields::{FromBytes, FromBytesError, ToBytes};
-use crate::types::{EndpointV4, EndpointV6};
+use crate::types::{EndpointV6, SocketAddrV4};
 use std::fmt::{Debug, Formatter};
 use std::io::Write;
 use typed_path::UnixPath;
@@ -12,7 +12,7 @@ pub enum SockAddr<'a> {
     Unix(&'a UnixPath),
 
     /// IPv4 sockets
-    V4(EndpointV4),
+    V4(SocketAddrV4),
 
     /// IPv6 socket
     V6(EndpointV6),
@@ -67,7 +67,7 @@ impl<'a> FromBytes<'a> for SockAddr<'a> {
                 Ok(Self::Unix(path))
             }
             PPM_AF_INET => {
-                let addr = EndpointV4::from_bytes(buf)?;
+                let addr = SocketAddrV4::from_bytes(buf)?;
                 Ok(Self::V4(addr))
             }
             PPM_AF_INET6 => {

--- a/falco_event/src/types/net/sockaddr.rs
+++ b/falco_event/src/types/net/sockaddr.rs
@@ -1,9 +1,8 @@
 use crate::ffi::{PPM_AF_INET, PPM_AF_INET6, PPM_AF_LOCAL, PPM_AF_UNSPEC};
 use crate::fields::{FromBytes, FromBytesError, ToBytes};
-use crate::types::SocketAddrV6;
 use std::fmt::{Debug, Formatter};
 use std::io::Write;
-use std::net::SocketAddrV4;
+use std::net::{SocketAddrV4, SocketAddrV6};
 use typed_path::UnixPath;
 
 /// A socket address
@@ -85,7 +84,7 @@ impl Debug for SockAddr<'_> {
         match self {
             SockAddr::Unix(u) => write!(f, "unix://{}", u.display()),
             SockAddr::V4(v4) => write!(f, "{v4}"),
-            SockAddr::V6(v6) => write!(f, "[{}]:{}", v6.0, v6.1),
+            SockAddr::V6(v6) => write!(f, "{v6}"),
             SockAddr::Other(af, raw) => write!(f, "<af={af}>{raw:02x?}"),
         }
     }

--- a/falco_event/src/types/net/sockaddr.rs
+++ b/falco_event/src/types/net/sockaddr.rs
@@ -1,6 +1,6 @@
 use crate::ffi::{PPM_AF_INET, PPM_AF_INET6, PPM_AF_LOCAL, PPM_AF_UNSPEC};
 use crate::fields::{FromBytes, FromBytesError, ToBytes};
-use crate::types::{EndpointV6, SocketAddrV4};
+use crate::types::{SocketAddrV4, SocketAddrV6};
 use std::fmt::{Debug, Formatter};
 use std::io::Write;
 use typed_path::UnixPath;
@@ -15,7 +15,7 @@ pub enum SockAddr<'a> {
     V4(SocketAddrV4),
 
     /// IPv6 socket
-    V6(EndpointV6),
+    V6(SocketAddrV6),
 
     /// any other address family is represented as the number (`PPM_AF_*` constant) and the raw data
     Other(u8, &'a [u8]),
@@ -71,7 +71,7 @@ impl<'a> FromBytes<'a> for SockAddr<'a> {
                 Ok(Self::V4(addr))
             }
             PPM_AF_INET6 => {
-                let addr = EndpointV6::from_bytes(buf)?;
+                let addr = SocketAddrV6::from_bytes(buf)?;
                 Ok(Self::V6(addr))
             }
             _ => Ok(Self::Other(*variant, std::mem::take(buf))),

--- a/falco_event/src/types/net/sockaddr.rs
+++ b/falco_event/src/types/net/sockaddr.rs
@@ -1,8 +1,9 @@
 use crate::ffi::{PPM_AF_INET, PPM_AF_INET6, PPM_AF_LOCAL, PPM_AF_UNSPEC};
 use crate::fields::{FromBytes, FromBytesError, ToBytes};
-use crate::types::{SocketAddrV4, SocketAddrV6};
+use crate::types::SocketAddrV6;
 use std::fmt::{Debug, Formatter};
 use std::io::Write;
+use std::net::SocketAddrV4;
 use typed_path::UnixPath;
 
 /// A socket address
@@ -83,7 +84,7 @@ impl Debug for SockAddr<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             SockAddr::Unix(u) => write!(f, "unix://{}", u.display()),
-            SockAddr::V4(v4) => write!(f, "{}:{}", v4.0, v4.1),
+            SockAddr::V4(v4) => write!(f, "{v4}"),
             SockAddr::V6(v6) => write!(f, "[{}]:{}", v6.0, v6.1),
             SockAddr::Other(af, raw) => write!(f, "<af={af}>{raw:02x?}"),
         }

--- a/falco_event/src/types/net/sockaddr.rs
+++ b/falco_event/src/types/net/sockaddr.rs
@@ -83,8 +83,8 @@ impl Debug for SockAddr<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             SockAddr::Unix(u) => write!(f, "unix://{}", u.display()),
-            SockAddr::V4(v4) => write!(f, "{}:{}", v4.0, v4.1 .0),
-            SockAddr::V6(v6) => write!(f, "[{}]:{}", v6.0, v6.1 .0),
+            SockAddr::V4(v4) => write!(f, "{}:{}", v4.0, v4.1),
+            SockAddr::V6(v6) => write!(f, "[{}]:{}", v6.0, v6.1),
             SockAddr::Other(af, raw) => write!(f, "<af={af}>{raw:02x?}"),
         }
     }

--- a/falco_event/src/types/net/socktuple.rs
+++ b/falco_event/src/types/net/socktuple.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 
 use crate::ffi::{PPM_AF_INET, PPM_AF_INET6, PPM_AF_LOCAL};
 use crate::fields::{FromBytes, FromBytesError, ToBytes};
-use crate::types::net::endpoint::{EndpointV6, SocketAddrV4};
+use crate::types::net::endpoint::{SocketAddrV4, SocketAddrV6};
 use typed_path::UnixPath;
 
 /// Socket tuple: describing both endpoints of a connection
@@ -30,9 +30,9 @@ pub enum SockTuple<'a> {
     /// IPv6 connection
     V6 {
         /// source address and port
-        source: EndpointV6,
+        source: SocketAddrV6,
         /// destination address and port
-        dest: EndpointV6,
+        dest: SocketAddrV6,
     },
 
     /// Unknown/other socket family: `PPM_AF_*` id and a raw byte buffer

--- a/falco_event/src/types/net/socktuple.rs
+++ b/falco_event/src/types/net/socktuple.rs
@@ -1,9 +1,9 @@
-use std::fmt::{Debug, Formatter};
-use std::io::Write;
-
 use crate::ffi::{PPM_AF_INET, PPM_AF_INET6, PPM_AF_LOCAL};
 use crate::fields::{FromBytes, FromBytesError, ToBytes};
-use crate::types::net::endpoint::{SocketAddrV4, SocketAddrV6};
+use crate::types::SocketAddrV6;
+use std::fmt::{Debug, Formatter};
+use std::io::Write;
+use std::net::SocketAddrV4;
 use typed_path::UnixPath;
 
 /// Socket tuple: describing both endpoints of a connection
@@ -48,7 +48,7 @@ impl Debug for SockTuple<'_> {
                 path,
             } => write!(f, "{:x}->{:x} {}", source_ptr, dest_ptr, path.display()),
             Self::V4 { source, dest } => {
-                write!(f, "{}:{} -> {}:{}", source.0, source.1, dest.0, dest.1)
+                write!(f, "{source} -> {dest}")
             }
             Self::V6 { source, dest } => {
                 write!(f, "[{}]:{} -> [{}]:{}", source.0, source.1, dest.0, dest.1)
@@ -142,8 +142,8 @@ mod tests {
     #[test]
     fn test_socktuple_ipv4() {
         let socktuple = SockTuple::V4 {
-            source: (Ipv4Addr::from_str("172.31.33.48").unwrap(), 47263),
-            dest: (Ipv4Addr::from_str("172.31.0.2").unwrap(), 53),
+            source: SocketAddrV4::new(Ipv4Addr::from_str("172.31.33.48").unwrap(), 47263),
+            dest: SocketAddrV4::new(Ipv4Addr::from_str("172.31.0.2").unwrap(), 53),
         };
 
         dbg!(&socktuple);

--- a/falco_event/src/types/net/socktuple.rs
+++ b/falco_event/src/types/net/socktuple.rs
@@ -1,9 +1,8 @@
 use crate::ffi::{PPM_AF_INET, PPM_AF_INET6, PPM_AF_LOCAL};
 use crate::fields::{FromBytes, FromBytesError, ToBytes};
-use crate::types::SocketAddrV6;
 use std::fmt::{Debug, Formatter};
 use std::io::Write;
-use std::net::SocketAddrV4;
+use std::net::{SocketAddrV4, SocketAddrV6};
 use typed_path::UnixPath;
 
 /// Socket tuple: describing both endpoints of a connection
@@ -51,7 +50,7 @@ impl Debug for SockTuple<'_> {
                 write!(f, "{source} -> {dest}")
             }
             Self::V6 { source, dest } => {
-                write!(f, "[{}]:{} -> [{}]:{}", source.0, source.1, dest.0, dest.1)
+                write!(f, "{source} -> {dest}")
             }
             Self::Other(af, buf) => f
                 .debug_struct("SockTuple")
@@ -164,8 +163,18 @@ mod tests {
     #[test]
     fn test_socktuple_ipv6() {
         let socktuple = SockTuple::V6 {
-            source: (Ipv6Addr::from_str("2001:4860:4860::8844").unwrap(), 47263),
-            dest: (Ipv6Addr::from_str("2001:4860:4860::8800").unwrap(), 53),
+            source: SocketAddrV6::new(
+                Ipv6Addr::from_str("2001:4860:4860::8844").unwrap(),
+                47263,
+                0,
+                0,
+            ),
+            dest: SocketAddrV6::new(
+                Ipv6Addr::from_str("2001:4860:4860::8800").unwrap(),
+                53,
+                0,
+                0,
+            ),
         };
 
         dbg!(&socktuple);

--- a/falco_event/src/types/net/socktuple.rs
+++ b/falco_event/src/types/net/socktuple.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 
 use crate::ffi::{PPM_AF_INET, PPM_AF_INET6, PPM_AF_LOCAL};
 use crate::fields::{FromBytes, FromBytesError, ToBytes};
-use crate::types::net::endpoint::{EndpointV4, EndpointV6};
+use crate::types::net::endpoint::{EndpointV6, SocketAddrV4};
 use typed_path::UnixPath;
 
 /// Socket tuple: describing both endpoints of a connection
@@ -22,9 +22,9 @@ pub enum SockTuple<'a> {
     /// IPv4 connection
     V4 {
         /// source address and port
-        source: EndpointV4,
+        source: SocketAddrV4,
         /// destination address and port
-        dest: EndpointV4,
+        dest: SocketAddrV4,
     },
 
     /// IPv6 connection

--- a/falco_event/src/types/net/socktuple.rs
+++ b/falco_event/src/types/net/socktuple.rs
@@ -47,16 +47,12 @@ impl Debug for SockTuple<'_> {
                 dest_ptr,
                 path,
             } => write!(f, "{:x}->{:x} {}", source_ptr, dest_ptr, path.display()),
-            Self::V4 { source, dest } => write!(
-                f,
-                "{}:{} -> {}:{}",
-                source.0, source.1 .0, dest.0, dest.1 .0
-            ),
-            Self::V6 { source, dest } => write!(
-                f,
-                "[{}]:{} -> [{}]:{}",
-                source.0, source.1 .0, dest.0, dest.1 .0
-            ),
+            Self::V4 { source, dest } => {
+                write!(f, "{}:{} -> {}:{}", source.0, source.1, dest.0, dest.1)
+            }
+            Self::V6 { source, dest } => {
+                write!(f, "[{}]:{} -> [{}]:{}", source.0, source.1, dest.0, dest.1)
+            }
             Self::Other(af, buf) => f
                 .debug_struct("SockTuple")
                 .field("af", &af)
@@ -140,15 +136,14 @@ impl<'a> FromBytes<'a> for SockTuple<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::Port;
     use std::net::{Ipv4Addr, Ipv6Addr};
     use std::str::FromStr;
 
     #[test]
     fn test_socktuple_ipv4() {
         let socktuple = SockTuple::V4 {
-            source: (Ipv4Addr::from_str("172.31.33.48").unwrap(), Port(47263)),
-            dest: (Ipv4Addr::from_str("172.31.0.2").unwrap(), Port(53)),
+            source: (Ipv4Addr::from_str("172.31.33.48").unwrap(), 47263),
+            dest: (Ipv4Addr::from_str("172.31.0.2").unwrap(), 53),
         };
 
         dbg!(&socktuple);
@@ -169,14 +164,8 @@ mod tests {
     #[test]
     fn test_socktuple_ipv6() {
         let socktuple = SockTuple::V6 {
-            source: (
-                Ipv6Addr::from_str("2001:4860:4860::8844").unwrap(),
-                Port(47263),
-            ),
-            dest: (
-                Ipv6Addr::from_str("2001:4860:4860::8800").unwrap(),
-                Port(53),
-            ),
+            source: (Ipv6Addr::from_str("2001:4860:4860::8844").unwrap(), 47263),
+            dest: (Ipv6Addr::from_str("2001:4860:4860::8800").unwrap(), 53),
         };
 
         dbg!(&socktuple);

--- a/falco_event_serde/src/ser/field/net.rs
+++ b/falco_event_serde/src/ser/field/net.rs
@@ -9,9 +9,7 @@ impl Serialize for SerializedField<&types::PT_SOCKADDR<'_>> {
     {
         match self.0 {
             types::PT_SOCKADDR::Unix(path) => SerializedField(path).serialize(serializer),
-            types::PT_SOCKADDR::V4((addr, port)) => {
-                (addr, SerializedField(port)).serialize(serializer)
-            }
+            types::PT_SOCKADDR::V4(v4) => (v4.ip(), v4.port()).serialize(serializer),
             types::PT_SOCKADDR::V6((addr, port)) => {
                 (addr, SerializedField(port)).serialize(serializer)
             }
@@ -31,13 +29,9 @@ impl Serialize for SerializedField<&types::PT_SOCKTUPLE<'_>> {
                 dest_ptr,
                 path,
             } => (source_ptr, dest_ptr, SerializedField(path)).serialize(serializer),
-            types::PT_SOCKTUPLE::V4 { source, dest } => (
-                source.0,
-                SerializedField(&source.1),
-                dest.0,
-                SerializedField(&dest.1),
-            )
-                .serialize(serializer),
+            types::PT_SOCKTUPLE::V4 { source, dest } => {
+                (source.ip(), source.port(), dest.ip(), dest.port()).serialize(serializer)
+            }
             types::PT_SOCKTUPLE::V6 { source, dest } => (
                 source.0,
                 SerializedField(&source.1),

--- a/falco_event_serde/src/ser/field/net.rs
+++ b/falco_event_serde/src/ser/field/net.rs
@@ -10,9 +10,7 @@ impl Serialize for SerializedField<&types::PT_SOCKADDR<'_>> {
         match self.0 {
             types::PT_SOCKADDR::Unix(path) => SerializedField(path).serialize(serializer),
             types::PT_SOCKADDR::V4(v4) => (v4.ip(), v4.port()).serialize(serializer),
-            types::PT_SOCKADDR::V6((addr, port)) => {
-                (addr, SerializedField(port)).serialize(serializer)
-            }
+            types::PT_SOCKADDR::V6(v6) => (v6.ip(), v6.port()).serialize(serializer),
             types::PT_SOCKADDR::Other(af, addr) => (af, StrOrBytes(addr)).serialize(serializer),
         }
     }
@@ -32,13 +30,9 @@ impl Serialize for SerializedField<&types::PT_SOCKTUPLE<'_>> {
             types::PT_SOCKTUPLE::V4 { source, dest } => {
                 (source.ip(), source.port(), dest.ip(), dest.port()).serialize(serializer)
             }
-            types::PT_SOCKTUPLE::V6 { source, dest } => (
-                source.0,
-                SerializedField(&source.1),
-                dest.0,
-                SerializedField(&dest.1),
-            )
-                .serialize(serializer),
+            types::PT_SOCKTUPLE::V6 { source, dest } => {
+                (source.ip(), source.port(), dest.ip(), dest.port()).serialize(serializer)
+            }
             types::PT_SOCKTUPLE::Other(af, addr) => (af, StrOrBytes(addr)).serialize(serializer),
         }
     }

--- a/falco_event_serde/tests/sockaddr.rs
+++ b/falco_event_serde/tests/sockaddr.rs
@@ -20,9 +20,9 @@ fn test_deserialize_sockaddr_v4() {
     assert_eq!(event.params.fd, Some(PT_FD(1)));
 
     match event.params.addr {
-        Some(PT_SOCKADDR::V4((addr, port))) => {
-            assert_eq!(addr.to_string(), "192.168.1.2");
-            assert_eq!(port, 8080);
+        Some(PT_SOCKADDR::V4(addr)) => {
+            assert_eq!(addr.ip().to_string(), "192.168.1.2");
+            assert_eq!(addr.port(), 8080);
         }
         _ => panic!("Expected PT_SOCKADDR::V4, got {:?}", event.params.addr),
     }
@@ -48,9 +48,9 @@ fn test_roundtrip_sockaddr_v4() {
     assert_eq!(event.params.fd, Some(PT_FD(1)));
 
     match event.params.addr {
-        Some(PT_SOCKADDR::V4((addr, port))) => {
-            assert_eq!(addr.to_string(), "192.168.1.2");
-            assert_eq!(port, 8080);
+        Some(PT_SOCKADDR::V4(addr)) => {
+            assert_eq!(addr.ip().to_string(), "192.168.1.2");
+            assert_eq!(addr.port(), 8080);
         }
         _ => panic!("Expected PT_SOCKADDR::V4, got {:?}", event.params.addr),
     }

--- a/falco_event_serde/tests/sockaddr.rs
+++ b/falco_event_serde/tests/sockaddr.rs
@@ -1,5 +1,5 @@
 use falco_event::events::types::PPME_SOCKET_CONNECT_E;
-use falco_event::fields::types::{PT_FD, PT_PORT, PT_SOCKADDR};
+use falco_event::fields::types::{PT_FD, PT_SOCKADDR};
 
 #[test]
 fn test_deserialize_sockaddr_v4() {
@@ -22,7 +22,7 @@ fn test_deserialize_sockaddr_v4() {
     match event.params.addr {
         Some(PT_SOCKADDR::V4((addr, port))) => {
             assert_eq!(addr.to_string(), "192.168.1.2");
-            assert_eq!(port, PT_PORT(8080));
+            assert_eq!(port, 8080);
         }
         _ => panic!("Expected PT_SOCKADDR::V4, got {:?}", event.params.addr),
     }
@@ -50,7 +50,7 @@ fn test_roundtrip_sockaddr_v4() {
     match event.params.addr {
         Some(PT_SOCKADDR::V4((addr, port))) => {
             assert_eq!(addr.to_string(), "192.168.1.2");
-            assert_eq!(port, PT_PORT(8080));
+            assert_eq!(port, 8080);
         }
         _ => panic!("Expected PT_SOCKADDR::V4, got {:?}", event.params.addr),
     }
@@ -80,7 +80,7 @@ fn test_deserialize_sockaddr_v6() {
     match event.params.addr {
         Some(PT_SOCKADDR::V6((addr, port))) => {
             assert_eq!(addr.to_string(), "bad:beef:cafe::f00d");
-            assert_eq!(port, PT_PORT(8080));
+            assert_eq!(port, 8080);
         }
         _ => panic!("Expected PT_SOCKADDR::V6, got {:?}", event.params.addr),
     }
@@ -107,7 +107,7 @@ fn test_roundtrip_sockaddr_v6() {
     match event.params.addr {
         Some(PT_SOCKADDR::V6((addr, port))) => {
             assert_eq!(addr.to_string(), "bad:beef:cafe::f00d");
-            assert_eq!(port, PT_PORT(8080));
+            assert_eq!(port, 8080);
         }
         _ => panic!("Expected PT_SOCKADDR::V6, got {:?}", event.params.addr),
     }

--- a/falco_event_serde/tests/sockaddr.rs
+++ b/falco_event_serde/tests/sockaddr.rs
@@ -78,9 +78,9 @@ fn test_deserialize_sockaddr_v6() {
 
     assert_eq!(event.params.fd, Some(PT_FD(1)));
     match event.params.addr {
-        Some(PT_SOCKADDR::V6((addr, port))) => {
-            assert_eq!(addr.to_string(), "bad:beef:cafe::f00d");
-            assert_eq!(port, 8080);
+        Some(PT_SOCKADDR::V6(addr)) => {
+            assert_eq!(addr.ip().to_string(), "bad:beef:cafe::f00d");
+            assert_eq!(addr.port(), 8080);
         }
         _ => panic!("Expected PT_SOCKADDR::V6, got {:?}", event.params.addr),
     }
@@ -105,9 +105,9 @@ fn test_roundtrip_sockaddr_v6() {
 
     assert_eq!(event.params.fd, Some(PT_FD(1)));
     match event.params.addr {
-        Some(PT_SOCKADDR::V6((addr, port))) => {
-            assert_eq!(addr.to_string(), "bad:beef:cafe::f00d");
-            assert_eq!(port, 8080);
+        Some(PT_SOCKADDR::V6(addr)) => {
+            assert_eq!(addr.ip().to_string(), "bad:beef:cafe::f00d");
+            assert_eq!(addr.port(), 8080);
         }
         _ => panic!("Expected PT_SOCKADDR::V6, got {:?}", event.params.addr),
     }

--- a/falco_event_serde/tests/socktuple.rs
+++ b/falco_event_serde/tests/socktuple.rs
@@ -21,14 +21,11 @@ fn test_deserialize_socktuple_v4() {
     assert_eq!(event.params.res, Some(PT_ERRNO(0)));
     assert_eq!(event.params.fd, Some(PT_FD(1)));
     match event.params.tuple {
-        Some(PT_SOCKTUPLE::V4 {
-            source: (saddr, sport),
-            dest: (daddr, dport),
-        }) => {
-            assert_eq!(saddr.to_string(), "192.168.1.2");
-            assert_eq!(sport, 8080);
-            assert_eq!(daddr.to_string(), "192.168.88.1");
-            assert_eq!(dport, 9090);
+        Some(PT_SOCKTUPLE::V4 { source, dest }) => {
+            assert_eq!(source.ip().to_string(), "192.168.1.2");
+            assert_eq!(source.port(), 8080);
+            assert_eq!(dest.ip().to_string(), "192.168.88.1");
+            assert_eq!(dest.port(), 9090);
         }
         _ => panic!("Expected PT_SOCKTUPLE::V4, got {:?}", event.params.tuple),
     }
@@ -149,14 +146,11 @@ fn test_roundtrip_socktuple_v4() {
     assert_eq!(event.params.res, Some(PT_ERRNO(0)));
     assert_eq!(event.params.fd, Some(PT_FD(1)));
     match event.params.tuple {
-        Some(PT_SOCKTUPLE::V4 {
-            source: (saddr, sport),
-            dest: (daddr, dport),
-        }) => {
-            assert_eq!(saddr.to_string(), "192.168.1.2");
-            assert_eq!(sport, 8080);
-            assert_eq!(daddr.to_string(), "192.168.88.1");
-            assert_eq!(dport, 9090);
+        Some(PT_SOCKTUPLE::V4 { source, dest }) => {
+            assert_eq!(source.ip().to_string(), "192.168.1.2");
+            assert_eq!(source.port(), 8080);
+            assert_eq!(dest.ip().to_string(), "192.168.88.1");
+            assert_eq!(dest.port(), 9090);
         }
         _ => panic!("Expected PT_SOCKTUPLE::V4, got {:?}", event.params.tuple),
     }

--- a/falco_event_serde/tests/socktuple.rs
+++ b/falco_event_serde/tests/socktuple.rs
@@ -51,14 +51,11 @@ fn test_deserialize_socktuple_v6() {
     assert_eq!(event.params.res, Some(PT_ERRNO(0)));
     assert_eq!(event.params.fd, Some(PT_FD(1)));
     match event.params.tuple {
-        Some(PT_SOCKTUPLE::V6 {
-            source: (saddr, sport),
-            dest: (daddr, dport),
-        }) => {
-            assert_eq!(saddr.to_string(), "bad:beef:cafe::f00d");
-            assert_eq!(sport, 8080);
-            assert_eq!(daddr.to_string(), "f00d::c0ff:ee");
-            assert_eq!(dport, 9090);
+        Some(PT_SOCKTUPLE::V6 { source, dest }) => {
+            assert_eq!(source.ip().to_string(), "bad:beef:cafe::f00d");
+            assert_eq!(source.port(), 8080);
+            assert_eq!(dest.ip().to_string(), "f00d::c0ff:ee");
+            assert_eq!(dest.port(), 9090);
         }
         _ => panic!("Expected PT_SOCKTUPLE::V6, got {:?}", event.params.tuple),
     }
@@ -181,14 +178,11 @@ fn test_roundtrip_socktuple_v6() {
     assert_eq!(event.params.res, Some(PT_ERRNO(0)));
     assert_eq!(event.params.fd, Some(PT_FD(1)));
     match event.params.tuple {
-        Some(PT_SOCKTUPLE::V6 {
-            source: (saddr, sport),
-            dest: (daddr, dport),
-        }) => {
-            assert_eq!(saddr.to_string(), "bad:beef:cafe::f00d");
-            assert_eq!(sport, 8080);
-            assert_eq!(daddr.to_string(), "f00d::c0ff:ee");
-            assert_eq!(dport, 9090);
+        Some(PT_SOCKTUPLE::V6 { source, dest }) => {
+            assert_eq!(source.ip().to_string(), "bad:beef:cafe::f00d");
+            assert_eq!(source.port(), 8080);
+            assert_eq!(dest.ip().to_string(), "f00d::c0ff:ee");
+            assert_eq!(dest.port(), 9090);
         }
         _ => panic!("Expected PT_SOCKTUPLE::V6, got {:?}", event.params.tuple),
     }

--- a/falco_event_serde/tests/socktuple.rs
+++ b/falco_event_serde/tests/socktuple.rs
@@ -1,5 +1,5 @@
 use falco_event::events::types::PPME_SOCKET_CONNECT_X;
-use falco_event::fields::types::{PT_ERRNO, PT_FD, PT_PORT, PT_SOCKTUPLE};
+use falco_event::fields::types::{PT_ERRNO, PT_FD, PT_SOCKTUPLE};
 
 #[test]
 fn test_deserialize_socktuple_v4() {
@@ -26,9 +26,9 @@ fn test_deserialize_socktuple_v4() {
             dest: (daddr, dport),
         }) => {
             assert_eq!(saddr.to_string(), "192.168.1.2");
-            assert_eq!(sport, PT_PORT(8080));
+            assert_eq!(sport, 8080);
             assert_eq!(daddr.to_string(), "192.168.88.1");
-            assert_eq!(dport, PT_PORT(9090));
+            assert_eq!(dport, 9090);
         }
         _ => panic!("Expected PT_SOCKTUPLE::V4, got {:?}", event.params.tuple),
     }
@@ -59,9 +59,9 @@ fn test_deserialize_socktuple_v6() {
             dest: (daddr, dport),
         }) => {
             assert_eq!(saddr.to_string(), "bad:beef:cafe::f00d");
-            assert_eq!(sport, PT_PORT(8080));
+            assert_eq!(sport, 8080);
             assert_eq!(daddr.to_string(), "f00d::c0ff:ee");
-            assert_eq!(dport, PT_PORT(9090));
+            assert_eq!(dport, 9090);
         }
         _ => panic!("Expected PT_SOCKTUPLE::V6, got {:?}", event.params.tuple),
     }
@@ -154,9 +154,9 @@ fn test_roundtrip_socktuple_v4() {
             dest: (daddr, dport),
         }) => {
             assert_eq!(saddr.to_string(), "192.168.1.2");
-            assert_eq!(sport, PT_PORT(8080));
+            assert_eq!(sport, 8080);
             assert_eq!(daddr.to_string(), "192.168.88.1");
-            assert_eq!(dport, PT_PORT(9090));
+            assert_eq!(dport, 9090);
         }
         _ => panic!("Expected PT_SOCKTUPLE::V4, got {:?}", event.params.tuple),
     }
@@ -192,9 +192,9 @@ fn test_roundtrip_socktuple_v6() {
             dest: (daddr, dport),
         }) => {
             assert_eq!(saddr.to_string(), "bad:beef:cafe::f00d");
-            assert_eq!(sport, PT_PORT(8080));
+            assert_eq!(sport, 8080);
             assert_eq!(daddr.to_string(), "f00d::c0ff:ee");
-            assert_eq!(dport, PT_PORT(9090));
+            assert_eq!(dport, 9090);
         }
         _ => panic!("Expected PT_SOCKTUPLE::V6, got {:?}", event.params.tuple),
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area ci

/area event

> /area event_derive

> /area plugin

> /area plugin_api

> /area plugin_derive

> /area plugin_tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Another small cleanup, to avoid the dependency on the custom PT_PORT type and use more stdlib instead.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
action required: adapt uses of PT_SOCKADDR and PT_SOCKTUPLE to the new inner types
```