### PR TITLE
new(event)!: export derive macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "attribute-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0053e96dd3bec5b4879c23a138d6ef26f2cb936c9cdc96274ac2b9ed44b5bb54"
+dependencies = [
+ "attribute-derive-macro",
+ "derive-where",
+ "manyhow",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "attribute-derive-macro"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "463b53ad0fd5b460af4b1915fe045ff4d946d025fb6c4dc3337752eaa980f71b"
+dependencies = [
+ "collection_literals",
+ "interpolator",
+ "manyhow",
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+ "quote-use",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +222,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "collection_literals"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186dce98367766de751c42c4f03970fc60fc012296e706ccbb9d5df9b6c1e271"
 
 [[package]]
 name = "core-foundation-sys"
@@ -359,7 +395,7 @@ checksum = "47cf90c375e516cf601a57727744bdf7a547680a470a2e8a6580a12288cf0630"
 dependencies = [
  "heck",
  "indexmap",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -367,6 +403,17 @@ dependencies = [
  "strum",
  "syn",
  "void",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e73f2692d4bd3cac41dca28934a39894200c9fabf49586d77d0e5954af1d7902"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -417,6 +464,7 @@ dependencies = [
 name = "falco_event_derive"
 version = "0.4.0"
 dependencies = [
+ "attribute-derive",
  "proc-macro2",
  "quote",
  "syn",
@@ -578,6 +626,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "interpolator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -591,15 +645,6 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -659,6 +704,29 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "manyhow"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b33efb3ca6d3b07393750d4030418d594ab1139cee518f0dc88db70fec873587"
+dependencies = [
+ "manyhow-macros",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "manyhow-macros"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46fce34d199b78b6e6073abf984c9cf5fd3e9330145a93ee0738a7443e371495"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "memchr"
@@ -826,6 +894,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-utils"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeaf08a13de400bc215877b5bdc088f241b12eb42f0a548d3390dc1c56bb7071"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smallvec",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,6 +920,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "quote-use"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9619db1197b497a36178cfc736dc96b271fe918875fbf1344c436a7e93d0321e"
+dependencies = [
+ "quote",
+ "quote-use-macros",
+]
+
+[[package]]
+name = "quote-use-macros"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82ebfb7faafadc06a7ab141a6f67bcfb24cb8beb158c6fe933f2f035afa99f35"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/falco_event/README.md
+++ b/falco_event/README.md
@@ -114,9 +114,8 @@ if let Ok(openat2_e_event) = event.load::<types::PPME_SYSCALL_OPENAT2_E>() {
 ```
 
 On the other hand, if you do not expect any particular event type, but still want to have it
-as a strongly typed struct, you can use [events::RawEvent::load_any], which returns
-an `Event<AnyEvent>`, where [events::types::AnyEvent] is a large enum, encompassing all known event
-types.
+as a strongly typed struct, you can call `load::<AnyEvent>()`, where [events::types::AnyEvent]
+is a large enum, encompassing all known event types.
 
 Please note that the available methods in this case are very limited. Realistically, you can
 only expect a [std::fmt::Debug] implementation, though this may change over time. You can

--- a/falco_event/src/events/mod.rs
+++ b/falco_event/src/events/mod.rs
@@ -1,5 +1,6 @@
 pub use event::Event;
 pub use metadata::EventMetadata;
+pub use payload::event_direction;
 pub use payload::EventDirection;
 pub use payload::EventPayload;
 pub use payload::PayloadFromBytesError;

--- a/falco_event/src/events/payload.rs
+++ b/falco_event/src/events/payload.rs
@@ -11,7 +11,6 @@ pub enum EventDirection {
 
 pub trait EventPayload {
     const ID: u16;
-    const NAME: &'static str;
 
     type LengthType;
 }

--- a/falco_event/src/events/payload.rs
+++ b/falco_event/src/events/payload.rs
@@ -11,8 +11,6 @@ pub enum EventDirection {
 
 pub trait EventPayload {
     const ID: u16;
-
-    type LengthType;
 }
 
 pub const fn event_direction(event_type_id: u16) -> EventDirection {

--- a/falco_event/src/events/payload.rs
+++ b/falco_event/src/events/payload.rs
@@ -1,4 +1,3 @@
-use crate::events::types::EventType;
 use crate::events::EventMetadata;
 use crate::fields::FromBytesError;
 use std::io::Write;
@@ -11,13 +10,13 @@ pub enum EventDirection {
 }
 
 pub trait EventPayload {
-    const ID: EventType;
+    const ID: u16;
     const NAME: &'static str;
 
     type LengthType;
 
     fn direction() -> EventDirection {
-        match Self::ID as u32 % 2 {
+        match Self::ID % 2 {
             0 => EventDirection::Entry,
             1 => EventDirection::Exit,
             _ => unreachable!(),

--- a/falco_event/src/events/payload.rs
+++ b/falco_event/src/events/payload.rs
@@ -14,13 +14,13 @@ pub trait EventPayload {
     const NAME: &'static str;
 
     type LengthType;
+}
 
-    fn direction() -> EventDirection {
-        match Self::ID % 2 {
-            0 => EventDirection::Entry,
-            1 => EventDirection::Exit,
-            _ => unreachable!(),
-        }
+pub const fn event_direction(event_type_id: u16) -> EventDirection {
+    match event_type_id % 2 {
+        0 => EventDirection::Entry,
+        1 => EventDirection::Exit,
+        _ => unreachable!(),
     }
 }
 

--- a/falco_event/src/events/payload.rs
+++ b/falco_event/src/events/payload.rs
@@ -40,7 +40,7 @@ pub enum PayloadFromBytesError {
 
     /// Unsupported event type
     #[error("unsupported event type {0}")]
-    UnsupportedEventType(u32),
+    UnsupportedEventType(u16),
 }
 
 pub trait PayloadToBytes {

--- a/falco_event/src/lib.rs
+++ b/falco_event/src/lib.rs
@@ -2,8 +2,126 @@
 #![warn(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
 
+/// # Derive event-related traits for an enum
+///
+/// Use this macro to define an enum like `falco_event::events::types::AnyEvent`, that is usable
+/// wherever another event type is. For example,
+///
+/// ```
+/// use std::borrow::Cow;
+/// use std::ffi::CStr;
+/// use anyhow::{anyhow, Context};
+/// use falco_event::events::PayloadFromBytesError;
+///
+/// #[derive(Default, Debug, falco_event::EventPayload)]
+/// #[event_payload(code = 322, length_type = u32)]
+/// pub struct MyPluginEvent<'a> {
+///     pub plugin_id: u32,
+///     pub data: &'a [u8],
+/// }
+///
+/// #[derive(Default, Debug, falco_event::EventPayload)]
+/// #[event_payload(code = 322, length_type = u32)]
+/// pub struct MyAsyncEvent<'a> {
+///     pub plugin_id: u32,
+///     pub name: &'a [u8],
+///     pub data: &'a [u8],
+/// }
+///
+/// #[derive(falco_event_derive::AnyEvent)]
+/// pub enum AnyPluginEvent<'a> {
+///     AsyncEvent(MyAsyncEvent<'a>),
+///     PluginEvent(MyPluginEvent<'a>),
+/// }
+/// ```
+///
+/// If the `falco_event` crate is available under a different path, provide its name
+/// in the `falco_event_crate` attribute:
+///
+/// ```ignore
+/// #[derive(falco_event::AnyEvent)]
+/// #[falco_event_crate(falco_event_alt)]
+/// pub enum AnyPluginEvent<'a> {
+///     AsyncEvent(MyAsyncEvent<'a>),
+///     PluginEvent(MyPluginEvent<'a>),
+/// }
+/// ```
+///
+/// ## Requirements
+///
+/// To use this macro on an enum, all its variants need to have exactly one unnamed field,
+/// which implements the following traits:
+/// * [`std::fmt::Debug`], for a string representation
+/// * [`events::EventPayload`], which indicates the type id (and source) of the variant
+/// * [`events::FromRawEvent`], which handles deserialization of the variant
+/// * [`events::PayloadToBytes`], which handles serialization of the variant
+///
+/// One way to fullfil these requirements is to use the [`EventPayload`]
+/// macro on the variant field's type.
+///
+/// ## Derived traits
+///
+/// This macro implements the following traits on the enum type:
+/// * [`std::fmt::Debug`], by delegating to each variant (without additional wrapping)
+/// * [`events::EventPayload`], which describes a whole set of type ids and sources supported
+///   by the enum (one for each variant)
+/// * [`events::FromRawEvent`], for deserialization
+/// * [`events::PayloadToBytes`], for serialization
+pub use falco_event_derive::AnyEvent;
+
 #[cfg(feature = "derive_deftly")]
 pub use derive_deftly;
+/// # Derive event-related traits for a struct
+///
+/// Use this macro to define new event types. For example, the PPME_PLUGINEVENT_E
+/// event could be defined as:
+///
+/// ```
+/// # use std::borrow::Cow;
+///
+/// #[derive(Default, falco_event::EventPayload)]
+/// #[event_payload(code = 322, length_type = u32)]
+/// pub struct MyPluginEvent<'a> {
+///     pub plugin_id: u32,
+///     pub data: &'a [u8],
+/// }
+/// ```
+///
+/// If the `falco_event` crate is available under a different path, provide its name
+/// in the `falco_event_crate` attribute:
+///
+/// ```ignore
+/// # use std::borrow::Cow;
+///
+/// #[derive(Default, falco_event::EventPayload)]
+/// #[event_payload(code = 322, length_type = u32)]
+/// #[falco_event_crate(falco_event_alt)]
+/// pub struct MyPluginEvent<'a> {
+///     pub plugin_id: u32,
+///     pub data: &'a [u8],
+/// }
+/// ```
+///
+/// To make your struct usable as an event payload, use the `#[event_payload]` attribute
+/// with the following (required) parameters:
+/// * `source` (`Option<&str>`) -- the name of the event source, for use in plugin metadata
+/// * `code` (u16) -- the raw numeric event type id
+/// * `length_type` (u16 or u32) -- the type of parameter length; most events use `u16` but a few
+///   notable ones (like PPME_ASYNCEVENT_E and PPME_PLUGINEVENT_E) support larger parameter values
+///   and so their length type is `u32`
+///
+/// This macro can be used only on structs, not enums. Each field of the struct must implement
+/// [`fields::FromBytes`] and [`fields::FromBytes`]. Due to the requirements of FieldMeta-based
+/// deserialization, the whole struct must also implement [`Default`] and may have at most one
+/// lifetime generic parameter.
+///
+///
+/// See above for an example use.
+///
+/// This variant derives the following traits:
+/// * [`events::FromRawEvent`] to provide deserialization
+/// * [`events::PayloadToBytes`] to provide serialization
+pub use falco_event_derive::EventPayload;
 pub use num_traits;
 
 #[allow(missing_docs)]

--- a/falco_event_derive/Cargo.toml
+++ b/falco_event_derive/Cargo.toml
@@ -18,4 +18,5 @@ proc-macro = true
 [dependencies]
 quote = "1"
 proc-macro2 = "1.0"
-syn = "2"
+syn = "2.0.100"
+attribute-derive = "0.10.3"

--- a/falco_event_derive/README.md
+++ b/falco_event_derive/README.md
@@ -1,5 +1,3 @@
-# Helper proc macros for the falco_event library
+# Derive macros for custom event types
 
-This is a helper crate for `falco_event`. It serves no purpose other than make development of `falco_event` easier.
-
-> This place is not a place of honor… no highly esteemed deed is commemorated here… nothing valued is here.
+This crate contains derive macros useful for defining new event types. See the `falco_event` crate for documentation.

--- a/falco_event_derive/src/any_event.rs
+++ b/falco_event_derive/src/any_event.rs
@@ -1,0 +1,145 @@
+use crate::helpers::{add_raw_event_lifetimes, get_crate_path};
+use proc_macro2::Ident;
+use quote::quote;
+use syn::spanned::Spanned;
+use syn::{Data, DataEnum, Field, Fields, Generics};
+
+fn the_field(fields: &Fields) -> Result<&Field, syn::Error> {
+    match fields {
+        Fields::Unnamed(unnamed) if unnamed.unnamed.len() == 1 => {
+            Ok(unnamed.unnamed.first().unwrap())
+        }
+        _ => Err(syn::Error::new(
+            fields.span(),
+            "Only single unnamed fields are allowed",
+        )),
+    }
+}
+
+fn derive_debug_for_fields(variant_ident: &Ident, fields: &Fields) -> proc_macro2::TokenStream {
+    if let Err(e) = the_field(fields) {
+        return e.to_compile_error();
+    }
+    quote!(Self::#variant_ident(_0) => ::std::fmt::Debug::fmt(&_0, f),)
+}
+
+fn derive_binary_size_fields(
+    crate_path: &proc_macro2::TokenStream,
+    variant_ident: &Ident,
+    fields: &Fields,
+) -> proc_macro2::TokenStream {
+    if let Err(e) = the_field(fields) {
+        return e.to_compile_error();
+    }
+    quote!(Self::#variant_ident(_0) => #crate_path::events::PayloadToBytes::binary_size(_0),)
+}
+
+fn derive_payload_to_bytes_for_fields(
+    crate_path: &proc_macro2::TokenStream,
+    variant_ident: &Ident,
+    fields: &Fields,
+) -> proc_macro2::TokenStream {
+    if let Err(e) = the_field(fields) {
+        return e.to_compile_error();
+    }
+    quote!(Self::#variant_ident(_0) => #crate_path::events::PayloadToBytes::write(_0, metadata, writer),)
+}
+
+fn derive_try_from_raw_event_for_fields(
+    crate_path: &proc_macro2::TokenStream,
+    variant_ident: &Ident,
+    fields: &Fields,
+) -> proc_macro2::TokenStream {
+    let field = match the_field(fields) {
+        Ok(field) => field,
+        Err(err) => return err.to_compile_error(),
+    };
+    let ty = &field.ty;
+
+    quote!(<#ty as #crate_path::events::EventPayload>::ID =>
+        Self::#variant_ident(<#ty as #crate_path::events::FromRawEvent>::parse(raw)?),
+    )
+}
+
+fn derive_any_event(
+    crate_path: &proc_macro2::TokenStream,
+    name: &Ident,
+    generics: &Generics,
+    e: &DataEnum,
+) -> proc_macro2::TokenStream {
+    let fmts = e
+        .variants
+        .iter()
+        .map(|variant| derive_debug_for_fields(&variant.ident, &variant.fields));
+
+    let binary_size = e
+        .variants
+        .iter()
+        .map(|variant| derive_binary_size_fields(crate_path, &variant.ident, &variant.fields));
+
+    let to_bytes = e.variants.iter().map(|variant| {
+        derive_payload_to_bytes_for_fields(crate_path, &variant.ident, &variant.fields)
+    });
+
+    let try_from = e.variants.iter().map(|variant| {
+        derive_try_from_raw_event_for_fields(crate_path, &variant.ident, &variant.fields)
+    });
+
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let (impl_ref_generics, ref_where_clause) =
+        add_raw_event_lifetimes(name, generics, where_clause);
+
+    quote!(
+        impl #impl_generics ::std::fmt::Debug for #name #ty_generics #where_clause {
+            #[inline]
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                match self {
+                    #(#fmts)*
+                }
+            }
+        }
+
+        impl #impl_generics #crate_path::events::PayloadToBytes for #name #ty_generics #where_clause {
+            #[inline]
+            fn binary_size(&self) -> usize {
+                match self {
+                    #(#binary_size)*
+                }
+            }
+
+            #[inline]
+            fn write<W: ::std::io::Write>(&self, metadata: &#crate_path::events::EventMetadata, writer: W) -> ::std::io::Result<()> {
+                match self {
+                    #(#to_bytes)*
+                }
+            }
+        }
+
+        impl <#impl_ref_generics> #crate_path::events::FromRawEvent<'raw_event> for #name #ty_generics #ref_where_clause {
+            fn parse(raw: &#crate_path::events::RawEvent<'raw_event>) -> Result<Self, #crate_path::events::PayloadFromBytesError> {
+                let any: Self = match raw.event_type {
+                    #(#try_from)*
+                    other => return Err(#crate_path::events::PayloadFromBytesError::UnsupportedEventType(other)),
+                };
+                Ok(any)
+            }
+        }
+    )
+}
+
+pub fn any_event(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input: syn::DeriveInput = syn::parse(input).unwrap();
+
+    let crate_path = match get_crate_path(&input.attrs) {
+        Ok(path) => path,
+        Err(e) => return e.into(),
+    };
+
+    match input.data {
+        Data::Enum(e) => derive_any_event(&crate_path, &input.ident, &input.generics, &e).into(),
+        _ => syn::Error::new(input.span(), "AnyEvent can only be derived for enums")
+            .to_compile_error()
+            .into(),
+    }
+}

--- a/falco_event_derive/src/binary_payload.rs
+++ b/falco_event_derive/src/binary_payload.rs
@@ -1,11 +1,17 @@
 use proc_macro::TokenStream;
 
+use crate::helpers::get_crate_path;
 use quote::quote;
 use syn::{parse_macro_input, DeriveInput, Fields};
 
 pub fn derive_to_bytes(input: TokenStream) -> TokenStream {
     // Parse it as a proc macro
     let input = parse_macro_input!(input as DeriveInput);
+
+    let crate_path = match get_crate_path(&input.attrs) {
+        Ok(path) => path,
+        Err(e) => return e.into(),
+    };
 
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
@@ -30,7 +36,7 @@ pub fn derive_to_bytes(input: TokenStream) -> TokenStream {
             let num_fields = fields.named.len();
 
             return TokenStream::from(quote!(
-            impl #impl_generics crate::events::PayloadToBytes for #name #ty_generics #where_clause {
+            impl #impl_generics #crate_path::events::PayloadToBytes for #name #ty_generics #where_clause {
                 #[inline]
                 fn binary_size(&self) -> usize {
                     use crate::events::EventPayload;
@@ -43,8 +49,8 @@ pub fn derive_to_bytes(input: TokenStream) -> TokenStream {
                 }
 
                 fn write<W: std::io::Write>(&self, metadata: &crate::events::EventMetadata, mut writer: W) -> std::io::Result<()> {
-                    use crate::events::EventPayload;
-                    use crate::fields::ToBytes;
+                    use #crate_path::events::EventPayload;
+                    use #crate_path::fields::ToBytes;
 
                     const NUM_FIELDS: usize = #num_fields;
                     let lengths: [<Self as EventPayload>::LengthType; NUM_FIELDS] =
@@ -70,6 +76,11 @@ pub fn derive_to_bytes(input: TokenStream) -> TokenStream {
 pub fn derive_from_bytes(input: TokenStream) -> TokenStream {
     // Parse it as a proc macro
     let input = parse_macro_input!(input as DeriveInput);
+
+    let crate_path = match get_crate_path(&input.attrs) {
+        Ok(path) => path,
+        Err(e) => return e.into(),
+    };
 
     let (_, ty_generics, where_clause) = input.generics.split_for_impl();
 
@@ -100,12 +111,12 @@ pub fn derive_from_bytes(input: TokenStream) -> TokenStream {
 
             return TokenStream::from(quote!(
             impl<'a> crate::events::FromRawEvent<'a> for #name #ty_generics #where_clause {
-                fn parse(raw: &crate::events::RawEvent<'a>) -> Result<Self, crate::events::PayloadFromBytesError> {
-                    use crate::events::EventPayload;
-                    use crate::events::PayloadFromBytesError;
-                    use crate::events::RawEvent;
-                    use crate::fields::FromBytes;
-                    use crate::fields::FromBytesError;
+                fn parse(raw: &#crate_path::events::RawEvent<'a>) -> Result<Self, #crate_path::events::PayloadFromBytesError> {
+                    use #crate_path::events::EventPayload;
+                    use #crate_path::events::PayloadFromBytesError;
+                    use #crate_path::events::RawEvent;
+                    use #crate_path::fields::FromBytes;
+                    use #crate_path::fields::FromBytesError;
 
                     if raw.event_type != Self::ID as u16 {
                         return Err(PayloadFromBytesError::TypeMismatch);

--- a/falco_event_derive/src/binary_payload.rs
+++ b/falco_event_derive/src/binary_payload.rs
@@ -1,4 +1,4 @@
-use crate::helpers::get_crate_path;
+use crate::helpers::{add_raw_event_lifetimes, get_crate_path};
 use attribute_derive::FromAttr;
 use proc_macro2::Ident;
 use quote::quote;
@@ -64,10 +64,11 @@ fn derive_from_bytes(
     let length_type = &attrs.length_type;
     let event_code = &attrs.code;
     let members = s.fields.members();
+    let (impl_ref_generics, ref_where_clause) = add_raw_event_lifetimes(name, g, where_clause);
 
     quote!(
-        impl<'a> #crate_path::events::FromRawEvent<'a> for #name #ty_generics #where_clause {
-            fn parse(raw: &#crate_path::events::RawEvent<'a>) -> Result<Self, #crate_path::events::PayloadFromBytesError> {
+        impl <#impl_ref_generics> #crate_path::events::FromRawEvent<'raw_event> for #name #ty_generics #ref_where_clause {
+            fn parse(raw: &#crate_path::events::RawEvent<'raw_event>) -> Result<Self, #crate_path::events::PayloadFromBytesError> {
             use #crate_path::events::PayloadFromBytesError;
                 use #crate_path::events::RawEvent;
                 use #crate_path::fields::FromBytes;

--- a/falco_event_derive/src/binary_payload.rs
+++ b/falco_event_derive/src/binary_payload.rs
@@ -57,7 +57,7 @@ pub fn derive_to_bytes(input: TokenStream) -> TokenStream {
                     use crate::fields::ToBytes;
 
                     let mut size = 26;
-                    size += ::std::mem::size_of::<<Self as EventPayload>::LengthType>() * #num_fields;
+                    size += ::std::mem::size_of::<#length_type>() * #num_fields;
                     #(size += #field_sizes_usize;)*
                     size
                 }

--- a/falco_event_derive/src/binary_payload.rs
+++ b/falco_event_derive/src/binary_payload.rs
@@ -1,8 +1,9 @@
 use crate::helpers::get_crate_path;
 use attribute_derive::FromAttr;
-use proc_macro::TokenStream;
+use proc_macro2::Ident;
 use quote::quote;
-use syn::{parse_macro_input, DeriveInput, Fields};
+use syn::spanned::Spanned;
+use syn::{parse_macro_input, Data, DataStruct, DeriveInput, Generics};
 
 #[derive(FromAttr)]
 #[from_attr(ident = event_payload)]
@@ -11,84 +12,114 @@ struct EventPayloadAttrs {
     code: syn::Expr,
 }
 
-pub fn derive_to_bytes(input: TokenStream) -> TokenStream {
-    // Parse it as a proc macro
-    let input = parse_macro_input!(input as DeriveInput);
-    let attrs = match EventPayloadAttrs::from_attributes(&input.attrs) {
-        Ok(attrs) => attrs,
-        Err(err) => return err.to_compile_error().into(),
-    };
+fn derive_to_bytes(
+    crate_path: &proc_macro2::TokenStream,
+    name: &Ident,
+    s: &DataStruct,
+    g: &Generics,
+    attrs: &EventPayloadAttrs,
+) -> proc_macro2::TokenStream {
+    let (impl_generics, ty_generics, where_clause) = g.split_for_impl();
+    let length_type = &attrs.length_type;
+    let event_code = &attrs.code;
 
-    let crate_path = match get_crate_path(&input.attrs) {
-        Ok(path) => path,
-        Err(e) => return e.into(),
-    };
+    let field_sizes = s
+        .fields
+        .members()
+        .map(|field| quote!(#length_type::try_from(self.#field.binary_size()).unwrap()));
 
-    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let field_writes = s
+        .fields
+        .members()
+        .map(|field| quote!(self.#field.write(&mut writer)?;));
 
-    if let syn::Data::Struct(ref data) = input.data {
-        if let Fields::Named(ref fields) = data.fields {
-            let length_type = attrs.length_type;
-            let event_code = attrs.code;
+    let field_sizes_usize = s
+        .fields
+        .members()
+        .map(|field| quote!(self.#field.binary_size()));
 
-            let field_sizes = fields.named.iter().map(|field| {
-                let name = &field.ident;
-                quote!(#length_type::try_from(self.#name.binary_size()).unwrap())
-            });
+    let num_fields = s.fields.members().count();
 
-            let field_sizes_usize = fields.named.iter().map(|field| {
-                let name = &field.ident;
-                quote!(self.#name.binary_size())
-            });
+    quote!(
+        impl #impl_generics #crate_path::events::PayloadToBytes for #name #ty_generics #where_clause {
+            #[inline]
+            fn binary_size(&self) -> usize {
+                use #crate_path::fields::ToBytes;
 
-            let field_writes = fields.named.iter().map(|field| {
-                let name = &field.ident;
-                quote!(self.#name.write(&mut writer)?;)
-            });
-
-            let name = input.ident;
-            let num_fields = fields.named.len();
-
-            return TokenStream::from(quote!(
-            impl #impl_generics #crate_path::events::PayloadToBytes for #name #ty_generics #where_clause {
-                #[inline]
-                fn binary_size(&self) -> usize {
-                    use crate::events::EventPayload;
-                    use crate::fields::ToBytes;
-
-                    let mut size = 26;
-                    size += ::std::mem::size_of::<#length_type>() * #num_fields;
-                    #(size += #field_sizes_usize;)*
-                    size
-                }
-
-                fn write<W: std::io::Write>(&self, metadata: &crate::events::EventMetadata, mut writer: W) -> std::io::Result<()> {
-                    use #crate_path::events::EventPayload;
-                    use #crate_path::fields::ToBytes;
-
-                    const NUM_FIELDS: usize = #num_fields;
-                    let lengths: [#length_type; NUM_FIELDS] =
-                        [#(#field_sizes),*];
-
-                    metadata.write_header_with_lengths(#event_code, lengths, &mut writer)?;
-                    #(#field_writes)*
-                    Ok(())
-                }
+                let mut size = 26;
+                size += ::std::mem::size_of::<#length_type>() * #num_fields;
+                #(size += #field_sizes_usize;)*
+                size
             }
-            ));
-        }
-    }
 
-    TokenStream::from(
-        syn::Error::new(
-            input.ident.span(),
-            "Only structs with named fields can derive `ToBytes`",
-        )
-        .to_compile_error(),
+            fn write<W: std::io::Write>(&self, metadata: &#crate_path::events::EventMetadata, mut writer: W) -> std::io::Result<()> {
+                use #crate_path::events::EventPayload;
+                use #crate_path::fields::ToBytes;
+
+                const NUM_FIELDS: usize = #num_fields;
+                let lengths: [#length_type; NUM_FIELDS] =
+                    [#(#field_sizes),*];
+
+                metadata.write_header_with_lengths(#event_code, lengths, &mut writer)?;
+                #(#field_writes)*
+                Ok(())
+            }
+        }
     )
 }
-pub fn derive_from_bytes(input: TokenStream) -> TokenStream {
-    // Parse it as a proc macro
+
+fn derive_from_bytes(
+    crate_path: &proc_macro2::TokenStream,
+    name: &Ident,
+    s: &DataStruct,
+    g: &Generics,
+    attrs: &EventPayloadAttrs,
+) -> proc_macro2::TokenStream {
+    let (_impl_generics, ty_generics, where_clause) = g.split_for_impl();
+    let length_type = &attrs.length_type;
+    let event_code = &attrs.code;
+
+    let field_reads = s.fields.members().map(|field| {
+        quote!(
+            let mut maybe_next_field = params.next().transpose()
+                .map_err(|e| PayloadFromBytesError::NamedField(stringify!(#field), e))?;
+            let #field = FromBytes::from_maybe_bytes(maybe_next_field.as_mut())
+                .map_err(|e| PayloadFromBytesError::NamedField(stringify!(#field), e))?;
+            if let Some(buf) = maybe_next_field {
+                if !buf.is_empty() {
+                    return Err(PayloadFromBytesError::NamedField(stringify!(#field), FromBytesError::LeftoverData));
+                }
+            }
+        )
+    });
+
+    let field_names = s.fields.members();
+
+    quote!(
+        impl<'a> #crate_path::events::FromRawEvent<'a> for #name #ty_generics #where_clause {
+            fn parse(raw: &#crate_path::events::RawEvent<'a>) -> Result<Self, #crate_path::events::PayloadFromBytesError> {
+            use #crate_path::events::PayloadFromBytesError;
+                use #crate_path::events::RawEvent;
+                use #crate_path::fields::FromBytes;
+                use #crate_path::fields::FromBytesError;
+
+                if raw.event_type != #event_code {
+                    return Err(PayloadFromBytesError::TypeMismatch);
+                }
+
+                let mut params = raw.params::<#length_type>()?;
+
+                #(#field_reads)*
+
+                Ok(#name {
+                    #(#field_names),*
+                })
+            }
+        }
+    )
+}
+
+pub fn event_payload(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let attrs = match EventPayloadAttrs::from_attributes(&input.attrs) {
         Ok(attrs) => attrs,
@@ -100,66 +131,20 @@ pub fn derive_from_bytes(input: TokenStream) -> TokenStream {
         Err(e) => return e.into(),
     };
 
-    let (_, ty_generics, where_clause) = input.generics.split_for_impl();
+    match input.data {
+        Data::Struct(s) => {
+            let from_bytes =
+                derive_from_bytes(&crate_path, &input.ident, &s, &input.generics, &attrs);
+            let to_bytes = derive_to_bytes(&crate_path, &input.ident, &s, &input.generics, &attrs);
 
-    if let syn::Data::Struct(ref data) = input.data {
-        if let Fields::Named(ref fields) = data.fields {
-            let length_type = attrs.length_type;
-            let event_code = attrs.code;
-
-            let field_reads = fields.named.iter().map(|field| {
-                let name = &field.ident;
-                let name_str = name.as_ref().map(|i| i.to_string());
-                quote!(
-                    let mut maybe_next_field = params.next().transpose()
-                        .map_err(|e| PayloadFromBytesError::NamedField(#name_str, e))?;
-                    let #name = FromBytes::from_maybe_bytes(maybe_next_field.as_mut())
-                        .map_err(|e| PayloadFromBytesError::NamedField(#name_str, e))?;
-                    if let Some(buf) = maybe_next_field {
-                        if !buf.is_empty() {
-                            return Err(PayloadFromBytesError::NamedField(#name_str, FromBytesError::LeftoverData));
-                        }
-                    }
-                )
-            });
-
-            let field_names = fields.named.iter().map(|field| {
-                let name = &field.ident;
-                quote!(#name)
-            });
-
-            let name = input.ident;
-
-            return TokenStream::from(quote!(
-            impl<'a> crate::events::FromRawEvent<'a> for #name #ty_generics #where_clause {
-                fn parse(raw: &#crate_path::events::RawEvent<'a>) -> Result<Self, #crate_path::events::PayloadFromBytesError> {
-                    use #crate_path::events::PayloadFromBytesError;
-                    use #crate_path::events::RawEvent;
-                    use #crate_path::fields::FromBytes;
-                    use #crate_path::fields::FromBytesError;
-
-                    if raw.event_type != #event_code {
-                        return Err(PayloadFromBytesError::TypeMismatch);
-                    }
-
-                    let mut params = raw.params::<#length_type>()?;
-
-                    #(#field_reads)*
-
-                    Ok(#name {
-                        #(#field_names),*
-                    })
-                }
-            }
-            ));
+            quote!(
+                #to_bytes
+                #from_bytes
+            )
+            .into()
         }
+        _ => syn::Error::new(input.span(), "EventPayload can only be derived for structs")
+            .to_compile_error()
+            .into(),
     }
-
-    TokenStream::from(
-        syn::Error::new(
-            input.ident.span(),
-            "Only structs with named fields can derive `FromBytes`",
-        )
-        .to_compile_error(),
-    )
 }

--- a/falco_event_derive/src/event_info.rs
+++ b/falco_event_derive/src/event_info.rs
@@ -254,6 +254,10 @@ impl EventInfo {
             true => quote!(u32),
             false => quote!(u16),
         };
+        let length_type_str = match is_large {
+            true => "u32",
+            false => "u16",
+        };
 
         quote!(
             #[allow(non_camel_case_types)]
@@ -264,6 +268,7 @@ impl EventInfo {
             #[event_payload(length_type = #length_type, code = #raw_ident)]
             #[cfg_attr(all(not(docsrs), feature = "derive_deftly"), derive(derive_deftly::Deftly))]
             #[cfg_attr(all(not(docsrs), feature = "derive_deftly"), derive_deftly_adhoc(export))]
+            #[cfg_attr(all(not(docsrs), feature = "derive_deftly"), deftly(length_type = #length_type_str))]
             pub struct #event_code #lifetime {
                 #(#fields,)*
             }
@@ -274,8 +279,6 @@ impl EventInfo {
 
             impl #lifetime crate::events::EventPayload for #event_code #lifetime {
                 const ID: u16 = #raw_ident;
-
-                type LengthType = #length_type;
             }
 
             impl #lifetime ::std::fmt::Debug for #event_code #lifetime {

--- a/falco_event_derive/src/event_info.rs
+++ b/falco_event_derive/src/event_info.rs
@@ -276,10 +276,6 @@ impl EventInfo {
                 #(#dirfd_methods)*
             }
 
-            impl #lifetime crate::events::EventPayload for #event_code #lifetime {
-                const ID: u16 = #raw_ident;
-            }
-
             impl #lifetime ::std::fmt::Debug for #event_code #lifetime {
                 fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                     use std::fmt::Write;

--- a/falco_event_derive/src/event_info.rs
+++ b/falco_event_derive/src/event_info.rs
@@ -273,7 +273,6 @@ impl EventInfo {
 
             impl #lifetime crate::events::EventPayload for #event_code #lifetime {
                 const ID: u16 = #raw_ident;
-                const NAME: &'static str = #name;
 
                 type LengthType = #length_type;
             }

--- a/falco_event_derive/src/event_info.rs
+++ b/falco_event_derive/src/event_info.rs
@@ -262,8 +262,7 @@ impl EventInfo {
         quote!(
             #[allow(non_camel_case_types)]
             #[derive(Clone, Copy)]
-            #[derive(falco_event_derive::FromBytes)]
-            #[derive(falco_event_derive::ToBytes)]
+            #[derive(falco_event_derive::EventPayload)]
             #[falco_event_crate(crate)]
             #[event_payload(length_type = #length_type, code = #raw_ident)]
             #[cfg_attr(all(not(docsrs), feature = "derive_deftly"), derive(derive_deftly::Deftly))]

--- a/falco_event_derive/src/event_info.rs
+++ b/falco_event_derive/src/event_info.rs
@@ -420,30 +420,15 @@ fn event_type_enum(events: &Events) -> proc_macro2::TokenStream {
     )
 }
 
-fn raw_event_load_any() -> proc_macro2::TokenStream {
-    quote!(
-        impl<'e> crate::events::RawEvent<'e> {
-            pub fn load_any(
-                &self,
-            ) -> Result<crate::events::Event<AnyEvent<'e>>, crate::events::PayloadFromBytesError>
-            {
-                self.load::<AnyEvent>()
-            }
-        }
-    )
-}
-
 pub fn event_info(input: TokenStream) -> TokenStream {
     let events = parse_macro_input!(input as Events);
 
     let event_info_borrowed = event_info_variant(&events);
     let event_type_enum = event_type_enum(&events);
-    let raw_event_load_any = raw_event_load_any();
 
     quote!(
         #event_info_borrowed
         #event_type_enum
-        #raw_event_load_any
     )
     .into()
 }

--- a/falco_event_derive/src/event_info.rs
+++ b/falco_event_derive/src/event_info.rs
@@ -261,6 +261,7 @@ impl EventInfo {
             #[derive(falco_event_derive::FromBytes)]
             #[derive(falco_event_derive::ToBytes)]
             #[falco_event_crate(crate)]
+            #[event_payload(length_type = #length_type, code = #raw_ident)]
             #[cfg_attr(all(not(docsrs), feature = "derive_deftly"), derive(derive_deftly::Deftly))]
             #[cfg_attr(all(not(docsrs), feature = "derive_deftly"), derive_deftly_adhoc(export))]
             pub struct #event_code #lifetime {

--- a/falco_event_derive/src/event_info.rs
+++ b/falco_event_derive/src/event_info.rs
@@ -247,7 +247,7 @@ impl EventInfo {
             &format!("ppm_event_code_{}", self.event_code),
             self.event_code.span(),
         );
-        let raw_ident = quote!(crate::ffi::#raw_ident);
+        let raw_ident = quote!(crate::ffi::#raw_ident as u16);
 
         let is_large = self.flags.iter().any(|flag| *flag == "EF_LARGE_PAYLOAD");
         let length_type = match is_large {
@@ -272,7 +272,7 @@ impl EventInfo {
             }
 
             impl #lifetime crate::events::EventPayload for #event_code #lifetime {
-                const ID: u16 = #raw_ident as u16;
+                const ID: u16 = #raw_ident;
                 const NAME: &'static str = #name;
 
                 type LengthType = #length_type;
@@ -282,7 +282,7 @@ impl EventInfo {
                 fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                     use std::fmt::Write;
 
-                    match <Self as crate::events::EventPayload>::direction() {
+                    match crate::events::event_direction(#raw_ident) {
                         crate::events::EventDirection::Entry => f.write_str("> ")?,
                         crate::events::EventDirection::Exit => f.write_str("< ")?,
                     }

--- a/falco_event_derive/src/event_info.rs
+++ b/falco_event_derive/src/event_info.rs
@@ -260,6 +260,7 @@ impl EventInfo {
             #[derive(Clone, Copy)]
             #[derive(falco_event_derive::FromBytes)]
             #[derive(falco_event_derive::ToBytes)]
+            #[falco_event_crate(crate)]
             #[cfg_attr(all(not(docsrs), feature = "derive_deftly"), derive(derive_deftly::Deftly))]
             #[cfg_attr(all(not(docsrs), feature = "derive_deftly"), derive_deftly_adhoc(export))]
             pub struct #event_code #lifetime {

--- a/falco_event_derive/src/helpers.rs
+++ b/falco_event_derive/src/helpers.rs
@@ -1,0 +1,68 @@
+use attribute_derive::{AttributeIdent, FromAttr};
+use proc_macro2::Ident;
+use quote::quote;
+use syn::punctuated::Punctuated;
+use syn::token::Comma;
+use syn::{
+    GenericParam, Generics, Lifetime, LifetimeParam, PredicateLifetime, Token, WhereClause,
+    WherePredicate,
+};
+
+pub fn add_raw_event_lifetimes(
+    name: &Ident,
+    generics: &Generics,
+    where_clause: Option<&WhereClause>,
+) -> (Punctuated<GenericParam, Comma>, WhereClause) {
+    let mut impl_ref_generics: Punctuated<GenericParam, syn::token::Comma> =
+        generics.params.iter().cloned().collect();
+
+    let raw_event_lt = Lifetime::new("'raw_event", name.span());
+    let mut ref_where_clause = where_clause.cloned().unwrap_or_else(|| WhereClause {
+        where_token: Default::default(),
+        predicates: Default::default(),
+    });
+
+    let mut outlives: Punctuated<Lifetime, syn::token::Plus> = Punctuated::new();
+    for g in &impl_ref_generics {
+        if let GenericParam::Lifetime(lt) = g {
+            outlives.push(lt.lifetime.clone());
+        }
+    }
+
+    if !outlives.is_empty() {
+        ref_where_clause
+            .predicates
+            .push(WherePredicate::Lifetime(PredicateLifetime {
+                lifetime: raw_event_lt.clone(),
+                colon_token: Token![:](name.span()),
+                bounds: outlives,
+            }));
+    }
+
+    impl_ref_generics.insert(0, GenericParam::Lifetime(LifetimeParam::new(raw_event_lt)));
+    (impl_ref_generics, ref_where_clause)
+}
+
+pub fn parse_attr<T: FromAttr + AttributeIdent>(
+    attrs: &[syn::Attribute],
+) -> Result<Option<T>, syn::Error> {
+    if attrs.iter().any(|attr| T::is_ident(attr.meta.path())) {
+        Ok(Some(T::from_attributes(attrs)?))
+    } else {
+        Ok(None)
+    }
+}
+
+#[derive(FromAttr)]
+#[from_attr(ident = falco_event_crate)]
+pub struct EventCratePath(pub syn::Path);
+
+pub fn get_crate_path(
+    attrs: &[syn::Attribute],
+) -> Result<proc_macro2::TokenStream, proc_macro2::TokenStream> {
+    match parse_attr::<EventCratePath>(attrs) {
+        Ok(Some(EventCratePath(crate_path))) => Ok(quote!(#crate_path)),
+        Ok(None) => Ok(quote!(falco_event)),
+        Err(e) => Err(e.to_compile_error()),
+    }
+}

--- a/falco_event_derive/src/lib.rs
+++ b/falco_event_derive/src/lib.rs
@@ -8,12 +8,12 @@ mod event_info;
 mod format;
 mod helpers;
 
-#[proc_macro_derive(ToBytes)]
+#[proc_macro_derive(ToBytes, attributes(falco_event_crate))]
 pub fn derive_to_bytes(input: TokenStream) -> TokenStream {
     binary_payload::derive_to_bytes(input)
 }
 
-#[proc_macro_derive(FromBytes)]
+#[proc_macro_derive(FromBytes, attributes(falco_event_crate))]
 pub fn derive_from_bytes(input: TokenStream) -> TokenStream {
     binary_payload::derive_from_bytes(input)
 }

--- a/falco_event_derive/src/lib.rs
+++ b/falco_event_derive/src/lib.rs
@@ -8,14 +8,9 @@ mod event_info;
 mod format;
 mod helpers;
 
-#[proc_macro_derive(ToBytes, attributes(event_payload, falco_event_crate))]
-pub fn derive_to_bytes(input: TokenStream) -> TokenStream {
-    binary_payload::derive_to_bytes(input)
-}
-
-#[proc_macro_derive(FromBytes, attributes(event_payload, falco_event_crate))]
-pub fn derive_from_bytes(input: TokenStream) -> TokenStream {
-    binary_payload::derive_from_bytes(input)
+#[proc_macro_derive(EventPayload, attributes(event_payload, falco_event_crate))]
+pub fn derive_event_payload(input: TokenStream) -> TokenStream {
+    binary_payload::event_payload(input)
 }
 
 #[proc_macro_derive(AnyEvent, attributes(falco_event_crate))]

--- a/falco_event_derive/src/lib.rs
+++ b/falco_event_derive/src/lib.rs
@@ -1,3 +1,6 @@
+#![doc = include_str!("../README.md")]
+#![deny(rustdoc::broken_intra_doc_links)]
+
 use proc_macro::TokenStream;
 
 mod any_event;
@@ -19,16 +22,19 @@ pub fn any_event(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro]
+#[doc(hidden)]
 pub fn event_info(input: TokenStream) -> TokenStream {
     event_info::event_info(input)
 }
 
 #[proc_macro]
+#[doc(hidden)]
 pub fn event_flags(input: TokenStream) -> TokenStream {
     event_flags::event_flags(input)
 }
 
 #[proc_macro]
+#[doc(hidden)]
 pub fn dynamic_params(input: TokenStream) -> TokenStream {
     dynamic_params::dynamic_params(input)
 }

--- a/falco_event_derive/src/lib.rs
+++ b/falco_event_derive/src/lib.rs
@@ -8,12 +8,12 @@ mod event_info;
 mod format;
 mod helpers;
 
-#[proc_macro_derive(ToBytes, attributes(falco_event_crate))]
+#[proc_macro_derive(ToBytes, attributes(event_payload, falco_event_crate))]
 pub fn derive_to_bytes(input: TokenStream) -> TokenStream {
     binary_payload::derive_to_bytes(input)
 }
 
-#[proc_macro_derive(FromBytes, attributes(falco_event_crate))]
+#[proc_macro_derive(FromBytes, attributes(event_payload, falco_event_crate))]
 pub fn derive_from_bytes(input: TokenStream) -> TokenStream {
     binary_payload::derive_from_bytes(input)
 }

--- a/falco_event_derive/src/lib.rs
+++ b/falco_event_derive/src/lib.rs
@@ -1,10 +1,12 @@
 use proc_macro::TokenStream;
 
+mod any_event;
 mod binary_payload;
 mod dynamic_params;
 mod event_flags;
 mod event_info;
 mod format;
+mod helpers;
 
 #[proc_macro_derive(ToBytes)]
 pub fn derive_to_bytes(input: TokenStream) -> TokenStream {
@@ -14,6 +16,11 @@ pub fn derive_to_bytes(input: TokenStream) -> TokenStream {
 #[proc_macro_derive(FromBytes)]
 pub fn derive_from_bytes(input: TokenStream) -> TokenStream {
     binary_payload::derive_from_bytes(input)
+}
+
+#[proc_macro_derive(AnyEvent, attributes(falco_event_crate))]
+pub fn any_event(input: TokenStream) -> TokenStream {
+    any_event::any_event(input)
 }
 
 #[proc_macro]

--- a/falco_event_serde/src/de/payload.rs
+++ b/falco_event_serde/src/de/payload.rs
@@ -18,7 +18,7 @@ falco_event::derive_deftly_for_events! {
             ];
 
             let event_type_id = <falco_event::events::types::$ttype as EventPayload>::ID;
-            let large_payload = match size_of::<<falco_event::events::types::$ttype as EventPayload>::LengthType>() {
+            let large_payload = match size_of::<${tmeta(length_type) as ty}>() {
                 2 => false,
                 4 => true,
                 _ => panic!("Invalid length type for event payload"),

--- a/falco_event_serde/src/de/payload.rs
+++ b/falco_event_serde/src/de/payload.rs
@@ -17,7 +17,7 @@ falco_event::derive_deftly_for_events! {
                 $(self.$fname.repr,)
             ];
 
-            let event_type_id = <falco_event::events::types::$ttype as EventPayload>::ID as u16;
+            let event_type_id = <falco_event::events::types::$ttype as EventPayload>::ID;
             let large_payload = match size_of::<<falco_event::events::types::$ttype as EventPayload>::LengthType>() {
                 2 => false,
                 4 => true,

--- a/falco_plugin/src/lib.rs
+++ b/falco_plugin/src/lib.rs
@@ -136,6 +136,7 @@ pub mod extract {
 ///
 /// ```
 ///# use std::ffi::CStr;
+/// use falco_event::events::types::AnyEvent;
 /// use falco_plugin::anyhow::Error;
 /// use falco_plugin::event::events::types::EventType;
 /// use falco_plugin::base::Plugin;
@@ -166,7 +167,7 @@ pub mod extract {
 ///     fn parse_event(&mut self, event: &EventInput, parse_input: &ParseInput)
 ///         -> Result<(), Error> {
 ///         let event = event.event()?;
-///         let event = event.load_any()?;
+///         let event = event.load::<AnyEvent>()?;
 ///
 ///         // any processing you want here, e.g. involving tables
 ///

--- a/falco_plugin_tests/benches/binary_event.rs
+++ b/falco_plugin_tests/benches/binary_event.rs
@@ -505,7 +505,7 @@ const EVENTS: &[&[u8]] = &[
 ];
 
 fn test_parse(event: &[u8]) {
-    RawEvent::from(event).unwrap().load_any().unwrap();
+    RawEvent::from(event).unwrap().load::<AnyEvent>().unwrap();
 }
 
 fn test_dump(event: &Event<AnyEvent>, out: &mut Vec<u8>) {
@@ -529,7 +529,7 @@ fn bench_dump(c: &mut Criterion) {
     let mut g = c.benchmark_group("event_dump_one");
     for (i, event) in EVENTS.iter().enumerate() {
         let raw_event = RawEvent::from(event).unwrap();
-        let event = raw_event.load_any().unwrap();
+        let event = raw_event.load::<AnyEvent>().unwrap();
         let mut out = Vec::new();
         g.throughput(Throughput::Elements(1));
         g.bench_with_input(BenchmarkId::new("dump", i), &event, |b, e| {

--- a/falco_plugin_tests/benches/binary_event_all.rs
+++ b/falco_plugin_tests/benches/binary_event_all.rs
@@ -6,13 +6,13 @@ use std::path::PathBuf;
 
 fn load(events: &[u8]) -> Vec<Event<AnyEvent<'_>>> {
     RawEvent::scan(events)
-        .map(|event| event.unwrap().load_any().unwrap())
+        .map(|event| event.unwrap().load::<AnyEvent>().unwrap())
         .collect()
 }
 
 fn test_parse(events: &[u8]) {
     RawEvent::scan(events)
-        .map(|event| event.unwrap().load_any().unwrap())
+        .map(|event| event.unwrap().load::<AnyEvent>().unwrap())
         .for_each(|event| {
             black_box(event);
         });

--- a/falco_plugin_tests/tests/scap.rs
+++ b/falco_plugin_tests/tests/scap.rs
@@ -1,7 +1,7 @@
 use falco_plugin::anyhow;
 use falco_plugin::anyhow::{Context, Error};
 use falco_plugin::base::Plugin;
-use falco_plugin::event::events::types::EventType;
+use falco_plugin::event::events::types::{AnyEvent, EventType};
 use falco_plugin::extract::EventInput;
 use falco_plugin::parse::{ParseInput, ParsePlugin};
 use falco_plugin::static_plugin;
@@ -45,7 +45,7 @@ impl ParsePlugin for DummyPlugin {
             .event()
             .context(format!("loading raw event {})", self.event_num))?;
         event
-            .load_any()
+            .load::<AnyEvent>()
             .context(format!("parsing event #{} {event:?}", self.event_num))?;
 
         self.event_num += 1;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area ci

/area event

/area event_derive

> /area plugin

> /area plugin_api

> /area plugin_derive

> /area plugin_tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Make the event traits `#[derive]`able with public macros, rather than being effectively locked away in bespoke macros usable only by the `falco_event` crate. This opens up the possibility of defining custom event types. However, the main motivation is being able to move out all generated event definitions into a separate crate, which speeds up builds massively (3x faster builds for plugins that do not need the syscall schema).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
action required: replace `RawEvent::load_any` with `RawEvent::load<AnyEvent>`
action-required: some technically public but not really interesting ways to introspect events have changed. The compiler will guide you.
```